### PR TITLE
Add new field to AgentState struct

### DIFF
--- a/zendesk/livechat_agent_events.go
+++ b/zendesk/livechat_agent_events.go
@@ -108,6 +108,7 @@ type AgentState struct {
 	AgentID         UserID
 	EngagementCount uint64
 	Status          string
+	StatusSince     time.Time
 	Timestamp       time.Time
 }
 
@@ -164,6 +165,7 @@ func (s *AgentEventService) UpdateAgentStates(
 					}
 
 					agentState.Status = string(agentEvent.Value)
+					agentState.StatusSince = agentEvent.StartTime
 				}
 
 				s.agentStates[agentEvent.AgentID] = agentState


### PR DESCRIPTION
### Change to AgentState struct  
This change would introduce a new field to the AgentState struct, "StatusSince". This is the time that the agent entered their current status.  

This does not show when an agent entered "Invisible/Offline", as the existing behavior removes that AgentState from the array of AgentStates - Therefore there would be no "agentstate" to set the StatusSince field on. 