### PR TITLE
Add Tag type alias

### DIFF
--- a/zendesk/livechat_chats.go
+++ b/zendesk/livechat_chats.go
@@ -56,7 +56,7 @@ type Chat struct {
 	Triggered       bool             `json:"triggered"`
 	Unread          bool             `json:"unread"`
 	Missed          bool             `json:"missed"`
-	Tags            []string         `json:"tags"`
+	Tags            []Tag            `json:"tags"`
 	Type            string           `json:"type"`
 	History         []ChatHistory    `json:"history"`
 	DepartmentID    *GroupID         `json:"department_id"`

--- a/zendesk/support_organizations.go
+++ b/zendesk/support_organizations.go
@@ -32,7 +32,7 @@ type Organization struct {
 	Notes              string             `json:"notes"`
 	SharedComments     bool               `json:"shared_comments"`
 	SharedTickets      bool               `json:"shared_tickets"`
-	Tags               []string           `json:"tags"`
+	Tags               []Tag              `json:"tags"`
 	UpdatedAt          time.Time          `json:"updated_at"`
 	OrganizationFields OrganizationFields `json:"organization_fields"`
 }

--- a/zendesk/support_tickets.go
+++ b/zendesk/support_tickets.go
@@ -77,9 +77,9 @@ type TagsPayload struct {
 	Tags Tags `json:"tags"`
 }
 
-type Tags []string
+type Tags []Tag
 
-func (tags Tags) HasTag(targetTag string) bool {
+func (tags Tags) HasTag(targetTag Tag) bool {
 	for _, tag := range tags {
 		if tag == targetTag {
 			return true

--- a/zendesk/support_users.go
+++ b/zendesk/support_users.go
@@ -45,7 +45,7 @@ type User struct {
 	Signature            string          `json:"signature"`
 	Shared               bool            `json:"shared"`
 	Suspended            bool            `json:"suspended"`
-	Tags                 []string        `json:"tags"`
+	Tags                 []Tag           `json:"tags"`
 	TwoFactorAuthEnabled bool            `json:"two_factor_auth_enabled"`
 	UpdatedAt            time.Time       `json:"updated_at"`
 	Verified             bool            `json:"verified"`

--- a/zendesk/types.go
+++ b/zendesk/types.go
@@ -39,6 +39,7 @@ type (
 	ScheduleID          uint64
 	SectionID           uint64
 	SuspendedTicketID   uint64
+	Tag                 string
 	TicketAuditEventID  uint64
 	TicketAuditID       uint64
 	TicketFieldID       uint64

--- a/zendesk/types.go
+++ b/zendesk/types.go
@@ -3,8 +3,10 @@ package zendesk
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -68,6 +70,13 @@ func (userID *UserID) UnmarshalJSON(b []byte) error {
 	typeUint64, _ := strconv.ParseUint(targetString, 0, 64)
 	*userID = UserID(typeUint64)
 
+	return nil
+}
+
+func (tag Tag) Validate() error {
+	if strings.Contains(string(tag), " ") {
+		return errors.New("zendesk tag cannot contain spaces")
+	}
 	return nil
 }
 


### PR DESCRIPTION
### Enhancement Request  
Add a new type alias for "Tag". Common uses for Tags are to add these to Users, Organizations or Tickets to either add context, enable workflows or assist with reporting.

Tags cannot contain spaces - there is a Validate function attached to the Tag alias.