### PR TITLE
Adjust Audit Log type

### DIFF
--- a/zendesk/account_configuration_audit_logs.go
+++ b/zendesk/account_configuration_audit_logs.go
@@ -23,7 +23,7 @@ type AuditLog struct {
 	CreatedAt         time.Time      `json:"created_at"`
 	ID                AuditLogID     `json:"id"`
 	IPAddress         *string        `json:"ip_address"`
-	SourceID          uint64         `json:"source_id"`
+	SourceID          SourceID       `json:"source_id"`
 	SourceLabel       string         `json:"source_label"`
 	SourceType        string         `json:"source_type"`
 	URL               string         `json:"url"`

--- a/zendesk/types.go
+++ b/zendesk/types.go
@@ -54,6 +54,7 @@ type (
 	PermissionGroupID   uint64
 	ScheduleID          uint64
 	SectionID           uint64
+	SourceID            int64
 	SuspendedTicketID   uint64
 	Tag                 string
 	TicketAuditEventID  uint64


### PR DESCRIPTION
SourceID can be -1, so we need to change the SourceID field to a int64. As this is a named field, create a SourceID type alias for int64