### PR TITLE
Hotfix audit log sort

### DIFF
--- a/zendesk/account_configuration_audit_logs.go
+++ b/zendesk/account_configuration_audit_logs.go
@@ -41,7 +41,9 @@ func (s AuditLogService) List(
 	modifiers ...ListAccountConfigurationAuditLogModifier,
 ) error {
 	query := url.Values{}
+	// Default values
 	query.Set("page[size]", "100")
+	query.Set("sort", "+created_at")
 
 	for _, modifier := range modifiers {
 		modifier.ModifyListAccountConfigurationAuditLogRequest(&query)
@@ -85,6 +87,18 @@ type listAccountConfigurationAuditLogModifier func(queryParameters *url.Values)
 
 func (l listAccountConfigurationAuditLogModifier) ModifyListAccountConfigurationAuditLogRequest(queryParameters *url.Values) {
 	l(queryParameters)
+}
+
+func WithPageSize(pageSize uint8) listAccountConfigurationAuditLogModifier {
+	return listAccountConfigurationAuditLogModifier(func(queryParameters *url.Values) {
+		queryParameters.Set("page[size]", fmt.Sprintf("%d", pageSize))
+	})
+}
+
+func WithSort(field string, direction CursorPaginationSortDirection) listAccountConfigurationAuditLogModifier {
+	return listAccountConfigurationAuditLogModifier(func(queryParameters *url.Values) {
+		queryParameters.Set("sort", fmt.Sprintf("%s%s", direction, field))
+	})
 }
 
 func WithFilterForAction(action AuditLogAction) listAccountConfigurationAuditLogModifier {

--- a/zendesk/account_configuration_audit_logs.go
+++ b/zendesk/account_configuration_audit_logs.go
@@ -43,7 +43,7 @@ func (s AuditLogService) List(
 	query := url.Values{}
 	// Default values
 	query.Set("page[size]", "100")
-	query.Set("sort", "+created_at")
+	query.Set("sort", "created_at")
 
 	for _, modifier := range modifiers {
 		modifier.ModifyListAccountConfigurationAuditLogRequest(&query)

--- a/zendesk/pagination.go
+++ b/zendesk/pagination.go
@@ -16,3 +16,10 @@ type CursorPaginationLinks struct {
 	Last  string `json:"last"`
 	Next  string `json:"next"`
 }
+
+type CursorPaginationSortDirection string
+
+const (
+	Asc  CursorPaginationSortDirection = "+"
+	Desc CursorPaginationSortDirection = "-"
+)

--- a/zendesk/pagination.go
+++ b/zendesk/pagination.go
@@ -20,6 +20,6 @@ type CursorPaginationLinks struct {
 type CursorPaginationSortDirection string
 
 const (
-	Asc  CursorPaginationSortDirection = "+"
+	Asc  CursorPaginationSortDirection = ""
 	Desc CursorPaginationSortDirection = "-"
 )


### PR DESCRIPTION
The sort parameter expects either a "-" or a blank string to indicate direction. This fix removes the "+" default sort direction