### PR TITLE
Change UserID type from unsigned integer to signed integer

### DIFF
--- a/zendesk/support_ticket_comments_test.go
+++ b/zendesk/support_ticket_comments_test.go
@@ -50,3 +50,44 @@ func Test_Support_Ticket_Comments_List_200(t *testing.T) {
 		t.Fatalf("expected 2 comments, got %d", len(actual))
 	}
 }
+
+func Test_Support_Ticket_Comments_List_SystemComment_200(t *testing.T) {
+	ctx := context.Background()
+
+	z := createTestService(t, []study.RoundTripFunc{
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusOK,
+				FilePath:   "test_files/responses/support/ticket_comments/show_systemComment_200.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodGet,
+				Path:   "/api/v2/tickets/1000/comments",
+				Query: url.Values{
+					"page[size]": []string{"100"},
+				},
+			},
+		),
+	})
+
+	var exampleTicketID zendesk.TicketID = 1000
+
+	actual := []zendesk.TicketComment{}
+
+	if err := z.Support().TicketComments().ListByTicketID(
+		ctx,
+		exampleTicketID,
+		func(response zendesk.TicketCommentResponse) error {
+			actual = append(actual, response.Comments...)
+
+			return nil
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(actual) != 2 {
+		t.Fatalf("expected 2 comments, got %d", len(actual))
+	}
+}

--- a/zendesk/test_files/responses/support/ticket_comments/show_systemComment_200.json
+++ b/zendesk/test_files/responses/support/ticket_comments/show_systemComment_200.json
@@ -1,0 +1,61 @@
+{
+	"comments": [
+		{
+			"id": 2062578988107,
+			"type": "Comment",
+			"author_id": 129392,
+			"body": "Conversation with Kylo Ren\n\nURL: None",
+			"html_body": "<div class=\"zd-comment\" dir=\"auto\"><p dir=\"auto\">Conversation with Kylo Ren</p>\n\n<p dir=\"auto\">URL: None</p></div>",
+			"plain_body": "Conversation with Kylo Ren \n\n URL: None",
+			"public": false,
+			"attachments": [],
+			"audit_id": 123847171,
+			"via": {
+				"channel": "native_messaging",
+				"source": {
+					"from": {},
+					"to": {},
+					"rel": null
+				}
+			},
+			"created_at": "2022-01-19T16:49:56Z",
+			"metadata": {
+				"system": {},
+				"custom": {}
+			}
+		},
+		{
+			"id": 1804785483751,
+			"type": "Comment",
+			"author_id": -1,
+			"body": "Hi!",
+			"html_body": "Hi!",
+			"plain_body": "Hi!",
+			"public": true,
+			"attachments": [],
+			"audit_id": 1804785483711,
+			"via": {
+				"channel": "chat_transcript",
+				"source": {
+					"from": {},
+					"to": {},
+					"rel": null
+				}
+			},
+			"created_at": "2022-01-19T17:00:06Z",
+			"metadata": {
+				"system": {},
+				"custom": {}
+			}
+		}
+	],
+	"meta": {
+		"has_more": false,
+		"after_cursor": null,
+		"before_cursor": null
+	},
+	"links": {
+		"prev": null,
+		"next": null
+	}
+}

--- a/zendesk/types.go
+++ b/zendesk/types.go
@@ -109,9 +109,9 @@ type (
 
 func (userID *UserID) UnmarshalJSON(b []byte) error {
 	// Try it as a uint64 first
-	var targetUint64 uint64
-	if err := json.Unmarshal(b, &targetUint64); err == nil {
-		*userID = UserID(targetUint64)
+	var targetInt64 int64
+	if err := json.Unmarshal(b, &targetInt64); err == nil {
+		*userID = UserID(targetInt64)
 
 		return nil
 	}
@@ -122,8 +122,8 @@ func (userID *UserID) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	typeUint64, _ := strconv.ParseUint(targetString, 0, 64)
-	*userID = UserID(typeUint64)
+	typeInt64, _ := strconv.ParseInt(targetString, 10, 64)
+	*userID = UserID(typeInt64)
 
 	return nil
 }

--- a/zendesk/types.go
+++ b/zendesk/types.go
@@ -102,7 +102,7 @@ type (
 	TicketID                 uint64
 	UploadToken              string
 	UserFieldID              uint64
-	UserID                   uint64
+	UserID                   int64
 	IdentityID               uint64
 	UserSegmentID            uint64
 )


### PR DESCRIPTION
The system user account ID is -1 - when the system performs an action or makes a comment, it uses this signed integer.

Change UserID to this and also add a test to ensure that it can be used correctly