### PR TITLE
Handle Webhook Events and Triggers

### DIFF
--- a/zendesk/service.go
+++ b/zendesk/service.go
@@ -10,7 +10,6 @@ func NewService(
 	subDomain string,
 	zendeskAuth authentication,
 	chatCredentials ChatCredentials,
-	webhookSecret string,
 	opts ...configOption,
 ) *Service {
 	config := &internalConfig{

--- a/zendesk/service.go
+++ b/zendesk/service.go
@@ -10,6 +10,7 @@ func NewService(
 	subDomain string,
 	zendeskAuth authentication,
 	chatCredentials ChatCredentials,
+	webhookSecret string,
 	opts ...configOption,
 ) *Service {
 	config := &internalConfig{

--- a/zendesk/service.go
+++ b/zendesk/service.go
@@ -127,6 +127,9 @@ func NewService(
 				agentStates:      AgentStates{},
 			},
 		},
+		webhookService: &WebhookService{
+			client: c,
+		},
 	}
 }
 
@@ -136,6 +139,7 @@ type Service struct {
 	supportService              *SupportService
 	guideService                *GuideService
 	liveChatService             *LiveChatService
+	webhookService              *WebhookService
 }
 
 func (s *Service) SubDomain() string {
@@ -160,4 +164,9 @@ func (s *Service) Guide() *GuideService {
 // https://developer.zendesk.com/api-reference/live-chat/introduction/
 func (s *Service) LiveChat() *LiveChatService {
 	return s.liveChatService
+}
+
+// https://developer.zendesk.com/api-reference/webhooks/introduction/
+func (s *Service) Webhook() *WebhookService {
+	return s.webhookService
 }

--- a/zendesk/service_test.go
+++ b/zendesk/service_test.go
@@ -18,6 +18,7 @@ func createTestService(t *testing.T, queue []study.RoundTripFunc) *zendesk.Servi
 			ClientID:     "fake-client-id",
 			ClientSecret: "fake-client-secret",
 		},
+
 		zendesk.WithRoundTripper(study.RoundTripperQueue(t, queue)),
 	)
 }

--- a/zendesk/service_test.go
+++ b/zendesk/service_test.go
@@ -18,7 +18,6 @@ func createTestService(t *testing.T, queue []study.RoundTripFunc) *zendesk.Servi
 			ClientID:     "fake-client-id",
 			ClientSecret: "fake-client-secret",
 		},
-
 		zendesk.WithRoundTripper(study.RoundTripperQueue(t, queue)),
 	)
 }

--- a/zendesk/test_files/requests/webhook/trigger/ticket_update.json
+++ b/zendesk/test_files/requests/webhook/trigger/ticket_update.json
@@ -1,0 +1,9 @@
+{
+	"type": "End User Comment",
+	"ticketID": "12345",
+	"priority": "Normal",
+	"tags": "new",
+	"groupID": "9000",
+	"assigneeID": "9001",
+	"assigneeEmail": "kren@example.com"
+}

--- a/zendesk/test_files/requests/webhook/user/group_membership_created.json
+++ b/zendesk/test_files/requests/webhook/user/group_membership_created.json
@@ -1,0 +1,19 @@
+{
+	"type": "zen:event-type:user.group_membership_created",
+	"account_id": 12514403,
+	"id": "6b9bbadf-5725-4e92-bebe-7b71011bf5f1",
+	"subject": "zen:user:6596848315901",
+	"time": "2099-07-04T05:33:18Z",
+	"zendesk_event_version": "2022-06-20",
+	"detail": {
+		"created_at": "2099-07-04T05:27:58Z",
+		"default_group_id": "0",
+		"email": "user.name@example.com",
+		"external_id": "",
+		"id": "6596848315901",
+		"organization_id": "0",
+		"role": "end-user",
+		"updated_at": "2099-07-04T05:33:18Z"
+	},
+	"event": { "group": { "id": "1" } }
+}

--- a/zendesk/types.go
+++ b/zendesk/types.go
@@ -87,6 +87,7 @@ const (
 )
 
 type (
+	AccountID                uint64
 	ActorID                  int64
 	ArticleID                uint64
 	AttachmentID             uint64
@@ -106,6 +107,8 @@ type (
 	OrganizationFieldID      uint64
 	OrganizationMembershipID uint64
 	PermissionGroupID        uint64
+	PostID                   string
+	TopicID                  string
 	ReasonCode               uint64
 	ReasonID                 uint64
 	SatisfactionRatingID     uint64
@@ -124,6 +127,7 @@ type (
 	UserID                   int64
 	IdentityID               uint64
 	UserSegmentID            uint64
+	WebhookEventID           string
 )
 
 func (userID *UserID) UnmarshalJSON(b []byte) error {

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -1521,7 +1521,16 @@ func (s *WebhookService) HandleWebhookEvent(
 	)
 }
 
-func (s *WebhookService) HandleWebhookTrigger(handler func(b []byte) error, webhookSigningSecret string) http.Handler {
+func (s *WebhookService) HandleWebhookTrigger(
+	handler func(b []byte) error,
+	modifiers ...WebhookHandlerModifier,
+) http.Handler {
+	// Handle adding Authentication Methods and Verification Signature Secret
+	webhookHandlerOptions := WebhookHandlerOptions{}
+	for _, modifier := range modifiers {
+		modifier.ModifyWebhookRequest(&webhookHandlerOptions)
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		webhookBody, err := readWebhookBody(r)
 		if err != nil {
@@ -1530,8 +1539,8 @@ func (s *WebhookService) HandleWebhookTrigger(handler func(b []byte) error, webh
 			return
 		}
 
-		if webhookSigningSecret != "" {
-			if !s.verifyZendeskWebhookSignatureIsValid(r, webhookBody, webhookSigningSecret) {
+		if webhookHandlerOptions.webhookSigningSecret != "" {
+			if !s.verifyZendeskWebhookSignatureIsValid(r, webhookBody, webhookHandlerOptions.webhookSigningSecret) {
 				respondToWebhookRequest(w, http.StatusBadRequest, "Bad Request")
 
 				return

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -12,28 +12,21 @@ import (
 	"time"
 )
 
+const (
+	WebhookHeaderSignature          string = "X-Zendesk-Webhook-Signature"
+	WebhookHeaderSignatureTimestamp string = "X-Zendesk-Webhook-Signature-Timestamp"
+)
+
 // https://developer.zendesk.com/api-reference/webhooks/webhooks-api/webhooks/
 type WebhookService struct {
-	client               *client
-	webhookEventHandlers WebhookEventHandlers
+	client *client
 }
 
-type WebhookEventHandlers struct {
-	DefaultUserEventHandler func(e WebhookEventUser, webhookSecret string) error
-	UserEventHandlers       map[WebhookEventTypePrefix]func(e WebhookEventUser, webhookSecret string) error
-	// UserEventHandler                     func(e WebhookEventUser) error
-	// ArticleEventHandler                  func(e WebhookEventArticle) error
-	// OrganizationEventHandler             func(e WebhookEventOrganization) error
-	// CommunityPostEventHandler            func(e WebhookEventCommunityPost) error
-	// AgentAvailabilityEventHandler        func(e WebhookEventAgentAvailability) error
-	// OmnichannelRoutingConfigEventHandler func(e WebhookEventOmnichannelRoutingConfig) error
-
-}
+// type UserEventHandler[K WebhookUserEventData] func(e WebhookEventUser[K]) error
 
 type WebhookEventType string
 
 const (
-	WebhookEventTrigger                  WebhookEventType = "trigger_or_automation"
 	WebhookEventUserActive               WebhookEventType = "zen:event-type:user.active_changed"
 	WebhookEventOmnichannelConfigFeature WebhookEventType = "zen:event-type:omnichannel_config.omnichannel_routing_feature_changed"
 	// Other webhook events...
@@ -43,123 +36,105 @@ const (
 // NOTE: For Webhookss connected to Triggers or Automations, any structure can be defined by a Zendesk Administrator for the payload
 type WebhookTriggerEvent any
 
-type WebhookEventTypePrefix string
+func (s WebhookService) HandleWebhook(
+	processor func(requestBody []byte) error,
+	webhookSigningSecret string,
+) http.Handler {
+	return http.HandlerFunc(
+		func(
+			w http.ResponseWriter,
+			r *http.Request,
+		) {
+			// Verifying webhook requests is optional
+			if webhookSigningSecret != "" {
+				s.verifyZendeskWebhookSignature(w, r, webhookSigningSecret)
+			}
 
-const (
-	WebhookEventTypePrefixUser WebhookEventTypePrefix = "zen:event-type:user"
-)
+			// TODO: Include authentication methods
+			// https://developer.zendesk.com/documentation/webhooks/webhook-security-and-authentication/#webhook-authentication
 
-func (s WebhookService) HandleWebhook(w http.ResponseWriter, r *http.Request) http.Handler {
+			body, err := readWebhookBody(r)
+			if err != nil {
+				respondToWebhookRequest(
+					w,
+					http.StatusInternalServerError,
+					"Could not read Webhook Request body",
+				)
 
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				return
+			}
 
-	})
+			if err := processor(body); err != nil {
+				respondToWebhookRequest(
+					w,
+					http.StatusInternalServerError,
+					"Error occurred while processing webhook request",
+				)
+
+				return
+			}
+
+			respondToWebhookRequest(
+				w,
+				http.StatusOK,
+				"Successfully handled Webhook Request",
+			)
+		},
+	)
 }
 
-// func (s WebhookService) HandleWebhookUserEvent() http.Handler {
-// 	return s.VerifyZendeskWebhook(
-// 		webhookSecret,
-// 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-// 			bodyBytes, err := readWebhookBody(r)
-// 			if err != nil {
-// 				respondJSON(
-// 					w,
-// 					http.StatusInternalServerError,
-// 					"Could not read Webhook Request body",
-// 				)
-
-// 				return
-// 			}
-
-// 			eventType, err := validateWebhookEvent(bodyBytes, WebhookEventUserPrefix)
-// 			if err != nil {
-// 				respondJSON(
-// 					w,
-// 					http.StatusInternalServerError,
-// 					"Could not read Webhook Request body",
-// 				)
-
-// 				return
-// 			}
-
-// 			// Get the userevent struct
-// 			e := WebhookEventUser{}
-
-// 			if err := userEventProcessor(e); err != nil {
-// 				respondJSON(
-// 					w,
-// 					http.StatusInternalServerError,
-// 					"Unsuccessful handling of Webhook Request",
-// 				)
-
-// 				return
-// 			}
-
-// 			respondJSON(
-// 				w,
-// 				http.StatusOK,
-// 				"Successfully handled Webhook Request",
-// 			)
-// 		}),
-// 	)
-// }
-
 // https://developer.zendesk.com/documentation/webhooks/verifying/
-func (s WebhookService) VerifyZendeskWebhook(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		bodyBytes, err := io.ReadAll(r.Body)
-		if err != nil {
-			respondJSON(
-				w,
-				http.StatusBadRequest,
-				"Bad Request",
-			)
-		}
-		r.Body.Close()
-		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+func (s WebhookService) verifyZendeskWebhookSignature(w http.ResponseWriter, r *http.Request, webhookSigningSecret string) {
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		respondToWebhookRequest(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+		)
+	}
+	r.Body.Close()
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
-		expectedZendeskSignature := r.Header.Get("X-Zendesk-Webhook-Signature")
-		zendeskSignatureTimestamp := r.Header.Get("X-Zendesk-Webhook-Signature-Timestamp")
-		if expectedZendeskSignature == "" || zendeskSignatureTimestamp == "" {
-			respondJSON(
-				w,
-				http.StatusBadRequest,
-				"Bad Request",
-			)
+	expectedZendeskSignature := r.Header.Get(WebhookHeaderSignature)
+	zendeskSignatureTimestamp := r.Header.Get(WebhookHeaderSignatureTimestamp)
+	if expectedZendeskSignature == "" || zendeskSignatureTimestamp == "" {
+		respondToWebhookRequest(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+		)
 
-			return
-		}
+		return
+	}
 
-		actualZendeskSignature := buildZendeskSignature(zendeskSignatureTimestamp, bodyBytes, webhookSecret)
-		if expectedZendeskSignature != actualZendeskSignature {
-			respondJSON(
-				w,
-				http.StatusBadRequest,
-				"Bad Request",
-			)
+	actualZendeskSignature := buildZendeskSignature(zendeskSignatureTimestamp, bodyBytes, webhookSigningSecret)
+	if expectedZendeskSignature != actualZendeskSignature {
+		respondToWebhookRequest(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+		)
 
-			return
-		}
-
-		next.ServeHTTP(w, r)
-	})
+		return
+	}
 }
 
 func buildZendeskSignature(
 	timestamp string,
 	bodyBytes []byte,
-	secret string,
+	webhookSigningSecret string,
 ) string {
 	content := []byte(timestamp)
 	content = append(content, bodyBytes...)
 
-	hash := hmac.New(sha256.New, []byte(secret))
+	hash := hmac.New(sha256.New, []byte(webhookSigningSecret))
 	hash.Write(content)
 
 	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
 }
 
-func respondJSON(w http.ResponseWriter, status int, message string) {
+func respondToWebhookRequest(w http.ResponseWriter, status int, message string) {
 	encoder := json.NewEncoder(w)
 
 	w.Header().Set("Content-Type", "application/json")
@@ -207,12 +182,11 @@ type WebhookEventDetailArticle struct {
 
 // https://developer.zendesk.com/api-reference/webhooks/event-types/user-events/
 type WebhookEventUser struct {
-	Detail WebhookEventDetailUser `json:"detail"`
-	Event  any                    `json:"event"`
 	WebhookEvent
+	Event  any                    `json:"event"`
+	Detail WebhookEventDetailUser `json:"detail"`
 }
 
-// https://developer.zendesk.com/api-reference/webhooks/event-types/user-events/#detail-object-properties
 type WebhookEventDetailUser struct {
 	CreatedAt      time.Time    `json:"created_at"`
 	Email          string       `json:"email"`
@@ -223,6 +197,28 @@ type WebhookEventDetailUser struct {
 	Role           CustomRoleID `json:"role"`
 	UpdatedAt      time.Time    `json:"updated_at"`
 }
+
+// type WebhookEventUser[Event WebhookUserEventData] struct {
+// 	WebhookEvent
+// 	Event  Event                  `json:"event"`
+// 	Detail WebhookEventDetailUser `json:"detail"`
+// }
+
+// type WebhookUserEventData interface {
+// 	WebhookEventUserActiveStatusChanged | WebhookEventUserDetailsChanged
+// }
+
+// // https://developer.zendesk.com/api-reference/webhooks/event-types/user-events/#detail-object-properties
+
+// type WebhookEventUserActiveStatusChanged struct {
+// 	Current  bool `json:"current"`
+// 	Previous bool `json:"previous"`
+// }
+
+// type WebhookEventUserDetailsChanged struct {
+// 	Current  string `json:"current"`
+// 	Previous string `json:"previous"`
+// }
 
 // https://developer.zendesk.com/api-reference/webhooks/event-types/community-events/
 type WebhookEventCommunityPost struct {

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -198,8 +198,37 @@ type WebhookEvent struct {
 	Detail              any              `json:"detail"`
 }
 
+type WebhookHandlerOptions struct {
+	webhookSigningSecret string
+}
+
+type WebhookHandlerModifier interface {
+	ModifyWebhookRequest(webhookHandlerOptions *WebhookHandlerOptions)
+}
+
+type webhookRequestModifier func(webhookHandlerOptions *WebhookHandlerOptions)
+
+func (w webhookRequestModifier) ModifyWebhookRequest(webhookHandlerOptions *WebhookHandlerOptions) {
+	w(webhookHandlerOptions)
+}
+
+func WithSigningSecret(webhookSigningSecret string) webhookRequestModifier {
+	return webhookRequestModifier(func(webhookHandlerOptions *WebhookHandlerOptions) {
+		webhookHandlerOptions.webhookSigningSecret = webhookSigningSecret
+	})
+}
+
 //gocyclo:ignore
-func (s *WebhookService) HandleWebhookEvent(eventHandlers WebhookEventHandlers, webhookSigningSecret string) http.Handler {
+func (s *WebhookService) HandleWebhookEvent(
+	eventHandlers WebhookEventHandlers,
+	modifiers ...WebhookHandlerModifier,
+) http.Handler {
+	// Handle adding Authentication Methods and Verification Signature Secret
+	webhookHandlerOptions := WebhookHandlerOptions{}
+	for _, modifier := range modifiers {
+		modifier.ModifyWebhookRequest(&webhookHandlerOptions)
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		webhookBody, err := readWebhookBody(r)
 		if err != nil {
@@ -221,8 +250,8 @@ func (s *WebhookService) HandleWebhookEvent(eventHandlers WebhookEventHandlers, 
 			return
 		}
 
-		if webhookSigningSecret != "" {
-			if !s.verifyZendeskWebhookSignatureIsValid(r, webhookBody, webhookSigningSecret) {
+		if webhookHandlerOptions.webhookSigningSecret != "" {
+			if !s.verifyZendeskWebhookSignatureIsValid(r, webhookBody, webhookHandlerOptions.webhookSigningSecret) {
 				respondToWebhookRequest(w, http.StatusBadRequest, "Bad Request")
 
 				return
@@ -1522,51 +1551,30 @@ func (s *WebhookService) HandleWebhookTrigger(handler func(b []byte) error, webh
 }
 
 type WebhookEventOrganization[EventData WebhookOrganizationEventData] struct {
-	Type                WebhookEventType          `json:"type"`
-	AccountID           AccountID                 `json:"account_id"`
-	ID                  WebhookEventID            `json:"id"`
-	Time                time.Time                 `json:"time"`
-	ZendeskEventVersion string                    `json:"zendesk_event_version"`
-	Subject             string                    `json:"subject"`
-	Event               EventData                 `json:"event"`
-	Detail              WebhookEventArticleDetail `json:"detail"`
+	Type                WebhookEventType               `json:"type"`
+	AccountID           AccountID                      `json:"account_id"`
+	ID                  WebhookEventID                 `json:"id"`
+	Time                time.Time                      `json:"time"`
+	ZendeskEventVersion string                         `json:"zendesk_event_version"`
+	Subject             string                         `json:"subject"`
+	Event               EventData                      `json:"event"`
+	Detail              WebhookEventOrganizationDetail `json:"detail"`
+}
+
+type WebhookEventOrganizationDetail struct {
+	CreatedAt      time.Time `json:"created_at"`
+	ExternalID     string    `json:"external_id"`
+	GroupID        string    `json:"group_id"`
+	Email          string    `json:"email"`
+	ID             string    `json:"id"`
+	Name           string    `json:"name"`
+	SharedComments bool      `json:"shared_comments"`
+	SharedTickets  bool      `json:"shared_tickets"`
+	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 // https://developer.zendesk.com/api-reference/webhooks/event-types/webhook-event-types/
 type WebhookEventArticle[EventData WebhookArticleEventData] struct {
-	Type                WebhookEventType          `json:"type"`
-	AccountID           AccountID                 `json:"account_id"`
-	ID                  WebhookEventID            `json:"id"`
-	Time                time.Time                 `json:"time"`
-	ZendeskEventVersion string                    `json:"zendesk_event_version"`
-	Subject             string                    `json:"subject"`
-	Event               EventData                 `json:"event"`
-	Detail              WebhookEventArticleDetail `json:"detail"`
-}
-
-type WebhookEventCommunityPost[EventData WebhookCommunityPostEventData] struct {
-	Type                WebhookEventType          `json:"type"`
-	AccountID           AccountID                 `json:"account_id"`
-	ID                  WebhookEventID            `json:"id"`
-	Time                time.Time                 `json:"time"`
-	ZendeskEventVersion string                    `json:"zendesk_event_version"`
-	Subject             string                    `json:"subject"`
-	Event               EventData                 `json:"event"`
-	Detail              WebhookEventArticleDetail `json:"detail"`
-}
-
-type WebhookEventAgentState[EventData WebhookAgentStateEventData] struct {
-	Type                WebhookEventType          `json:"type"`
-	AccountID           AccountID                 `json:"account_id"`
-	ID                  WebhookEventID            `json:"id"`
-	Time                time.Time                 `json:"time"`
-	ZendeskEventVersion string                    `json:"zendesk_event_version"`
-	Subject             string                    `json:"subject"`
-	Event               EventData                 `json:"event"`
-	Detail              WebhookEventArticleDetail `json:"detail"`
-}
-
-type WebhookEventOmnichannelRoutingConfig[EventData WebhookOmnichannelRoutingConfigData] struct {
 	Type                WebhookEventType          `json:"type"`
 	AccountID           AccountID                 `json:"account_id"`
 	ID                  WebhookEventID            `json:"id"`
@@ -1583,12 +1591,64 @@ type WebhookEventArticleDetail struct {
 	ID      ArticleID `json:"id"`
 }
 
+type WebhookEventCommunityPost[EventData WebhookCommunityPostEventData] struct {
+	Type                WebhookEventType                `json:"type"`
+	AccountID           AccountID                       `json:"account_id"`
+	ID                  WebhookEventID                  `json:"id"`
+	Time                time.Time                       `json:"time"`
+	ZendeskEventVersion string                          `json:"zendesk_event_version"`
+	Subject             string                          `json:"subject"`
+	Event               EventData                       `json:"event"`
+	Detail              WebhookEventCommunityPostDetail `json:"detail"`
+}
+
+type WebhookEventCommunityPostDetail struct {
+	BrandID string `json:"brand_id"`
+	ID      string `json:"id"`
+	PostID  string `json:"post_id"`
+}
+
+type WebhookEventAgentState[EventData WebhookAgentStateEventData] struct {
+	Type                WebhookEventType             `json:"type"`
+	AccountID           AccountID                    `json:"account_id"`
+	ID                  WebhookEventID               `json:"id"`
+	Time                time.Time                    `json:"time"`
+	ZendeskEventVersion string                       `json:"zendesk_event_version"`
+	Subject             string                       `json:"subject"`
+	Event               EventData                    `json:"event"`
+	Detail              WebhookEventAgentStateDetail `json:"detail"`
+}
+
+type WebhookEventAgentStateDetail struct {
+	AccountID string `json:"account_id"`
+	AgentID   string `json:"agent_id"`
+	Version   string `json:"version"`
+}
+
+type WebhookEventOmnichannelRoutingConfig[EventData WebhookOmnichannelRoutingConfigData] struct {
+	Type                WebhookEventType                           `json:"type"`
+	AccountID           AccountID                                  `json:"account_id"`
+	ID                  WebhookEventID                             `json:"id"`
+	Time                time.Time                                  `json:"time"`
+	ZendeskEventVersion string                                     `json:"zendesk_event_version"`
+	Subject             string                                     `json:"subject"`
+	Event               EventData                                  `json:"event"`
+	Detail              WebhookEventOmnichannelRoutingConfigDetail `json:"detail"`
+}
+
+type WebhookEventOmnichannelRoutingConfigDetail struct {
+	AccountID string `json:"account_id"`
+}
+
 type WebhookArticleEventData interface {
 	EventTypeArticleAuthorChangedEvent | any
 }
 
 type WebhookOrganizationEventData interface {
-	any
+	WebhookEventDataEmpty |
+		WebhookEventDataCustomFieldUpdate |
+		WebhookEventDataSimpleStringUpdate |
+		WebhookEventDataTagsChanged
 }
 
 type WebhookAgentStateEventData interface {
@@ -1596,7 +1656,7 @@ type WebhookAgentStateEventData interface {
 }
 
 type WebhookOmnichannelRoutingConfigData interface {
-	any
+	WebhookEventDataSimpleBoolUpdateValue
 }
 
 type WebhookCommunityPostEventData interface {
@@ -1628,10 +1688,16 @@ type WebhookEventUserDetail struct {
 }
 
 type WebhookUserEventData interface {
-	WebhookEventUserAliasChangedPayload |
-		WebhookEventUserActiveStatusChangedPayload |
-		WebhookEventUserDetailsChangedPayload |
-		any
+	WebhookEventDataSimpleStringUpdate |
+		WebhookEventDataEmpty |
+		WebhookEventDataCustomFieldUpdate |
+		WebhookEventDataUserGroupMembershipChanged |
+		WebhookEventDataUserIdentityChanged |
+		WebhookEventDataUserIdentity |
+		WebhookEventDataSimpleBoolUpdate |
+		WebhookEventDataUserMerged |
+		WebhookEventDataUserOrganizationMembershipChanged |
+		WebhookEventDataTagsChanged
 }
 
 type WebhookEventUserActiveStatusChangedPayload struct {
@@ -1728,6 +1794,11 @@ type WebhookEventDataSimpleStringUpdate struct {
 type WebhookEventDataSimpleBoolUpdate struct {
 	Current  bool `json:"current"`
 	Previous bool `json:"previous"`
+}
+
+type WebhookEventDataSimpleBoolUpdateValue struct {
+	CurrentValue  bool `json:"current_value"`
+	PreviousValue bool `json:"previous_value"`
 }
 
 type WebhookEventDataEmpty struct{}
@@ -1860,4 +1931,6 @@ type (
 	WebhookEventAgentChannelDeletedPayload      WebhookEventAgentState[any]
 )
 
-type WebhookEventOmnichannelRoutingConfigFeatureChangedPayload WebhookEventOmnichannelRoutingConfig[any]
+type (
+	WebhookEventOmnichannelRoutingConfigFeatureChangedPayload WebhookEventOmnichannelRoutingConfig[WebhookEventDataSimpleBoolUpdateValue]
+)

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -1,17 +1,190 @@
 package zendesk
 
-import "time"
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"time"
+)
+
+// https://developer.zendesk.com/api-reference/webhooks/webhooks-api/webhooks/
+type WebhookService struct {
+	client               *client
+	webhookEventHandlers WebhookEventHandlers
+}
+
+type WebhookEventHandlers struct {
+	UserEventHandler                     func(e WebhookEventUser) error
+	ArticleEventHandler                  func(e WebhookEventArticle) error
+	OrganizationEventHandler             func(e WebhookEventOrganization) error
+	CommunityPostEventHandler            func(e WebhookEventCommunityPost) error
+	AgentAvailabilityEventHandler        func(e WebhookEventAgentAvailability) error
+	OmnichannelRoutingConfigEventHandler func(e WebhookEventOmnichannelRoutingConfig) error
+}
+
+func (s WebhookService) HandleWebhookUserEvent(
+	webhookSecret string,
+	userEventProcessor func(e WebhookEventUser) error,
+) http.Handler {
+	return s.VerifyZendeskWebhook(
+		webhookSecret,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			bodyBytes, err := readWebhookBody(r)
+			if err != nil {
+				respondJSON(
+					w,
+					http.StatusInternalServerError,
+					"Could not read Webhook Request body",
+				)
+
+				return
+			}
+
+			eventType, err := validateWebhookEvent(bodyBytes, WebhookEventUserPrefix)
+			if err != nil {
+				respondJSON(
+					w,
+					http.StatusInternalServerError,
+					"Could not read Webhook Request body",
+				)
+
+				return
+			}
+
+			// Get the userevent struct
+			e := WebhookEventUser{}
+
+			if err := userEventProcessor(e); err != nil {
+				respondJSON(
+					w,
+					http.StatusInternalServerError,
+					"Unsuccessful handling of Webhook Request",
+				)
+
+				return
+			}
+
+			respondJSON(
+				w,
+				http.StatusOK,
+				"Successfully handled Webhook Request",
+			)
+		}),
+	)
+}
+
+// https://developer.zendesk.com/documentation/webhooks/verifying/
+func (s WebhookService) VerifyZendeskWebhook(webhookSecret string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			respondJSON(
+				w,
+				http.StatusBadRequest,
+				"Bad Request",
+			)
+		}
+		r.Body.Close()
+		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+		expectedZendeskSignature := r.Header.Get("X-Zendesk-Webhook-Signature")
+		zendeskSignatureTimestamp := r.Header.Get("X-Zendesk-Webhook-Signature-Timestamp")
+		if expectedZendeskSignature == "" || zendeskSignatureTimestamp == "" {
+			respondJSON(
+				w,
+				http.StatusBadRequest,
+				"Bad Request",
+			)
+
+			return
+		}
+
+		actualZendeskSignature := buildZendeskSignature(zendeskSignatureTimestamp, bodyBytes, webhookSecret)
+		if expectedZendeskSignature != actualZendeskSignature {
+			respondJSON(
+				w,
+				http.StatusBadRequest,
+				"Bad Request",
+			)
+
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func buildZendeskSignature(
+	timestamp string,
+	bodyBytes []byte,
+	secret string,
+) string {
+	content := []byte(timestamp)
+	content = append(content, bodyBytes...)
+
+	hash := hmac.New(sha256.New, []byte(secret))
+	hash.Write(content)
+
+	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
+}
+
+func respondJSON(w http.ResponseWriter, status int, message string) {
+	encoder := json.NewEncoder(w)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	if err := encoder.Encode(message); err != nil {
+		return
+	}
+}
+
+func readWebhookBody(r *http.Request) ([]byte, error) {
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	r.Body.Close()
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	return bodyBytes, nil
+}
+
+func validateWebhookEvent(webhookPayload []byte) bool {
+	target := WebhookEvent{}
+	if err := json.Unmarshal(webhookPayload, &target); err != nil {
+		return "", err
+	}
+
+	if target.Type != "" {
+		return target.Type, nil
+	}
+
+	return WebhookEventTrigger, nil
+}
 
 type WebhookEventType string
 
 const (
-	WebhookEventUserActive         WebhookEventType = "zen:event-type:user.active_changed"
-	WebhookEventOmnichannelRouting WebhookEventType = "zen:event-type:omnichannel_config.omnichannel_routing_feature_changed"
+	WebhookEventTrigger                  WebhookEventType = "trigger_or_automation"
+	WebhookEventUserActive               WebhookEventType = "zen:event-type:user.active_changed"
+	WebhookEventOmnichannelConfigFeature WebhookEventType = "zen:event-type:omnichannel_config.omnichannel_routing_feature_changed"
 	// Other webhook events...
 )
 
+const (
+	WebhookEventUserPrefix              string = "zen:event-type:user"
+	WebhookEventOmnichannelConfigPrefix string = "zen:event-type:omnichannel_config"
+)
+
 // https://support.zendesk.com/hc/en-us/articles/4408839108378-Creating-webhooks-to-interact-with-third-party-systems#ariaid-title4
-// NOTE: For Webhook Trigger or Automation Payloads, any structure can be defined by a Zendesk Administrator
+// NOTE: For Webhookss connected to Triggers or Automations, any structure can be defined by a Zendesk Administrator for the payload
 type WebhookTriggerEvent any
 
 // https://developer.zendesk.com/api-reference/webhooks/event-types/webhook-event-types/
@@ -22,13 +195,12 @@ type WebhookEvent struct {
 	Time                time.Time        `json:"time"`
 	ZendeskEventVersion string           `json:"zendesk_event_version"`
 	Subject             string           `json:"subject"`
-	// Detail              any              `json:"detail"`
-	// Event               any              `json:"event"`
 }
 
+// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/
 type WebhookEventArticle struct {
 	Detail WebhookEventDetailArticle `json:"detail"`
-
+	Event  any                       `json:"event"`
 	WebhookEvent
 }
 
@@ -38,26 +210,14 @@ type WebhookEventDetailArticle struct {
 	ID      ArticleID `json:"id"`
 }
 
-// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
-type WebhookEventDetailCommunityPost struct {
-	BrandID BrandID `json:"brand_id"`
-	PostID  PostID  `json:"post_id"`
-	TopicID TopicID `json:"topic_id"`
+// https://developer.zendesk.com/api-reference/webhooks/event-types/user-events/
+type WebhookEventUser struct {
+	Detail WebhookEventDetailUser `json:"detail"`
+	Event  any                    `json:"event"`
+	WebhookEvent
 }
 
-// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
-type WebhookEventDetailOrganization struct {
-	CreatedAt      time.Time `json:"created_at"`
-	ExternalID     *string   `json:"external_id"`
-	GroupID        *string   `json:"group_id"`
-	ID             string    `json:"id"`
-	Name           string    `json:"name"`
-	SharedComments bool      `json:"shared_comments"`
-	SharedTickets  bool      `json:"shared_tickets"`
-	UpdatedAt      time.Time `json:"updated_at"`
-}
-
-// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
+// https://developer.zendesk.com/api-reference/webhooks/event-types/user-events/#detail-object-properties
 type WebhookEventDetailUser struct {
 	CreatedAt      time.Time    `json:"created_at"`
 	Email          string       `json:"email"`
@@ -69,6 +229,48 @@ type WebhookEventDetailUser struct {
 	UpdatedAt      time.Time    `json:"updated_at"`
 }
 
+type WebhookEventCommunityPost struct {
+	Detail WebhookEventDetailCommunityPost `json:"detail"`
+	Event  any                             `json:"event"`
+	WebhookEvent
+}
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
+type WebhookEventDetailCommunityPost struct {
+	BrandID BrandID `json:"brand_id"`
+	PostID  PostID  `json:"post_id"`
+	TopicID TopicID `json:"topic_id"`
+}
+
+type WebhookEventOrganization struct {
+	Detail WebhookEventDetailOrganization `json:"detail"`
+	Event  any                            `json:"event"`
+	WebhookEvent
+}
+
+type WebhookEventDetailOrganization struct {
+	CreatedAt      time.Time `json:"created_at"`
+	ExternalID     *string   `json:"external_id"`
+	GroupID        *string   `json:"group_id"`
+	ID             string    `json:"id"`
+	Name           string    `json:"name"`
+	SharedComments bool      `json:"shared_comments"`
+	SharedTickets  bool      `json:"shared_tickets"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type WebhookEventOmnichannelRoutingConfig struct {
+	Detail WebhookEventDetailOmnichannelRoutingConfig `json:"detail"`
+	Event  any                                        `json:"event"`
+	WebhookEvent
+}
+
+type WebhookEventAgentAvailability struct {
+	Detail WebhookEventDetailAgentAvailability `json:"detail"`
+	Event  any                                 `json:"event"`
+	WebhookEvent
+}
+
 // https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
 type WebhookEventDetailAgentAvailability struct {
 	AccountID AccountID `json:"account_id"`
@@ -77,9 +279,6 @@ type WebhookEventDetailAgentAvailability struct {
 }
 
 // https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
-type WebhookEventDetailOmnichannelRoutingConfiguration struct {
+type WebhookEventDetailOmnichannelRoutingConfig struct {
 	AccountID AccountID `json:"account_id"`
-}
-
-type WebhookEventEvent struct {
 }

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -22,8 +22,6 @@ type WebhookService struct {
 	client *client
 }
 
-// type UserEventHandler[K WebhookUserEventData] func(e WebhookEventUser[K]) error
-
 type WebhookEventType string
 
 const (
@@ -158,32 +156,30 @@ func readWebhookBody(r *http.Request) ([]byte, error) {
 }
 
 // https://developer.zendesk.com/api-reference/webhooks/event-types/webhook-event-types/
-type WebhookEvent struct {
+type WebhookEvent[Detail any, Event any] struct {
 	Type                WebhookEventType `json:"type"`
 	AccountID           AccountID        `json:"account_id"`
 	ID                  WebhookEventID   `json:"id"`
 	Time                time.Time        `json:"time"`
 	ZendeskEventVersion string           `json:"zendesk_event_version"`
 	Subject             string           `json:"subject"`
+	Event               Event            `json:"event"`
+	Detail              Detail           `json:"detail"`
 }
 
 // https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/
-type WebhookEventArticle struct {
-	Detail WebhookEventDetailArticle `json:"detail"`
-	Event  any                       `json:"event"`
-	WebhookEvent
-}
-
-// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
-type WebhookEventDetailArticle struct {
+type WebhookEventArticleDetail struct {
 	BrandID BrandID   `json:"brand_id"`
 	ID      ArticleID `json:"id"`
 }
 
-// https://developer.zendesk.com/api-reference/webhooks/event-types/user-events/
-type WebhookEventUser struct {
+type WebhookEventArticleAuthorChanged WebhookEvent[EventTypeArticleAuthorChangedEvent, EventTypeArticleAuthorChangedDetail]
+type EventTypeArticleAuthorChangedEvent struct{}
+type EventTypeArticleAuthorChangedDetail struct{}
+
+type WebhookEventUser[EventData WebhookUserEventData] struct {
 	WebhookEvent
-	Event  any                    `json:"event"`
+	Event  EventData              `json:"event"`
 	Detail WebhookEventDetailUser `json:"detail"`
 }
 
@@ -198,27 +194,48 @@ type WebhookEventDetailUser struct {
 	UpdatedAt      time.Time    `json:"updated_at"`
 }
 
+type WebhookEventHandlers struct {
+	EventTypeArticleAuthorChanged func(event EventTypeArticleAuthorChanged)
+}
+
+func (s WebhookService) WebhookEvent(handlers WebhookEventHandlers, secret string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// TODO: auth and unmarshal - hand wavy part
+
+		if subject && handlers.EventTypeArticleAuthorChanged != nil {
+			handlers.UserEvent(Event[User]{})
+			return
+		}
+	})
+}
+
+func (s WebhookService) WebhookTrigger(handler func(b []byte), secret string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+	})
+}
+
 // type WebhookEventUser[Event WebhookUserEventData] struct {
 // 	WebhookEvent
 // 	Event  Event                  `json:"event"`
 // 	Detail WebhookEventDetailUser `json:"detail"`
 // }
 
-// type WebhookUserEventData interface {
-// 	WebhookEventUserActiveStatusChanged | WebhookEventUserDetailsChanged
-// }
+type WebhookUserEventData interface {
+	WebhookEventUserActiveStatusChanged | WebhookEventUserDetailsChanged
+}
 
 // // https://developer.zendesk.com/api-reference/webhooks/event-types/user-events/#detail-object-properties
 
-// type WebhookEventUserActiveStatusChanged struct {
-// 	Current  bool `json:"current"`
-// 	Previous bool `json:"previous"`
-// }
+type WebhookEventUserActiveStatusChanged struct {
+	Current  bool `json:"current"`
+	Previous bool `json:"previous"`
+}
 
-// type WebhookEventUserDetailsChanged struct {
-// 	Current  string `json:"current"`
-// 	Previous string `json:"previous"`
-// }
+type WebhookEventUserDetailsChanged struct {
+	Current  string `json:"current"`
+	Previous string `json:"previous"`
+}
 
 // https://developer.zendesk.com/api-reference/webhooks/event-types/community-events/
 type WebhookEventCommunityPost struct {

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -5,10 +5,16 @@ import "time"
 type WebhookEventType string
 
 const (
-	WebhookEventUserActive WebhookEventType = "zen:event-type:user.active_changed"
+	WebhookEventUserActive         WebhookEventType = "zen:event-type:user.active_changed"
+	WebhookEventOmnichannelRouting WebhookEventType = "zen:event-type:omnichannel_config.omnichannel_routing_feature_changed"
 	// Other webhook events...
 )
 
+// https://support.zendesk.com/hc/en-us/articles/4408839108378-Creating-webhooks-to-interact-with-third-party-systems#ariaid-title4
+// NOTE: For Webhook Trigger or Automation Payloads, any structure can be defined by a Zendesk Administrator
+type WebhookTriggerEvent any
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/webhook-event-types/
 type WebhookEvent struct {
 	Type                WebhookEventType `json:"type"`
 	AccountID           AccountID        `json:"account_id"`
@@ -16,13 +22,63 @@ type WebhookEvent struct {
 	Time                time.Time        `json:"time"`
 	ZendeskEventVersion string           `json:"zendesk_event_version"`
 	Subject             string           `json:"subject"`
-	Detail              any              `json:"detail"`
-	Event               any              `json:"event"`
+	// Detail              any              `json:"detail"`
+	// Event               any              `json:"event"`
 }
 
+type WebhookEventArticle struct {
+	Detail WebhookEventDetailArticle `json:"detail"`
+
+	WebhookEvent
+}
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
 type WebhookEventDetailArticle struct {
 	BrandID BrandID   `json:"brand_id"`
 	ID      ArticleID `json:"id"`
+}
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
+type WebhookEventDetailCommunityPost struct {
+	BrandID BrandID `json:"brand_id"`
+	PostID  PostID  `json:"post_id"`
+	TopicID TopicID `json:"topic_id"`
+}
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
+type WebhookEventDetailOrganization struct {
+	CreatedAt      time.Time `json:"created_at"`
+	ExternalID     *string   `json:"external_id"`
+	GroupID        *string   `json:"group_id"`
+	ID             string    `json:"id"`
+	Name           string    `json:"name"`
+	SharedComments bool      `json:"shared_comments"`
+	SharedTickets  bool      `json:"shared_tickets"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
+type WebhookEventDetailUser struct {
+	CreatedAt      time.Time    `json:"created_at"`
+	Email          string       `json:"email"`
+	ExternalID     string       `json:"external_id"`
+	DefaultGroupID string       `json:"default_group_id"`
+	ID             string       `json:"id"`
+	OrganizationID string       `json:"organization_id"`
+	Role           CustomRoleID `json:"role"`
+	UpdatedAt      time.Time    `json:"updated_at"`
+}
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
+type WebhookEventDetailAgentAvailability struct {
+	AccountID AccountID `json:"account_id"`
+	AgentID   string    `json:"agent_id"`
+	Version   string    `json:"version"`
+}
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
+type WebhookEventDetailOmnichannelRoutingConfiguration struct {
+	AccountID AccountID `json:"account_id"`
 }
 
 type WebhookEventEvent struct {

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -260,7 +260,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -279,7 +279,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -298,7 +298,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -317,7 +317,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -336,7 +336,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -355,7 +355,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -374,7 +374,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -393,7 +393,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -412,7 +412,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -431,7 +431,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -452,7 +452,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -471,7 +471,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -490,7 +490,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -509,7 +509,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -528,7 +528,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -547,7 +547,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -568,7 +568,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -587,7 +587,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -606,7 +606,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -625,7 +625,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -644,7 +644,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -663,7 +663,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -682,7 +682,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -701,7 +701,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -720,7 +720,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -739,7 +739,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -758,7 +758,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -777,7 +777,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -796,7 +796,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -815,7 +815,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -834,7 +834,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -853,7 +853,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -872,7 +872,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -891,7 +891,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -910,7 +910,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -929,7 +929,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -948,7 +948,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -967,7 +967,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -986,7 +986,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1005,7 +1005,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1025,7 +1025,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1044,7 +1044,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1063,7 +1063,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1084,7 +1084,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1103,7 +1103,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1122,7 +1122,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1141,7 +1141,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1160,7 +1160,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1179,7 +1179,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1198,7 +1198,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1217,7 +1217,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1236,7 +1236,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1255,7 +1255,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1274,7 +1274,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1293,7 +1293,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1312,7 +1312,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1331,7 +1331,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1352,7 +1352,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1371,7 +1371,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1390,7 +1390,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1409,7 +1409,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1428,7 +1428,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1447,7 +1447,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1487,7 +1487,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"Server failed to process Webhook Request correctly",
 					)
 
 					return
@@ -1528,7 +1528,7 @@ func (s *WebhookService) HandleWebhookTrigger(
 
 		if handler != nil {
 			if err := handler(r.Context(), webhookBody); err != nil {
-				respondToWebhookRequest(w, http.StatusInternalServerError, err.Error())
+				respondToWebhookRequest(w, http.StatusInternalServerError, "Server failed to process Webhook Request correctly")
 
 				return
 			}

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -19,9 +19,7 @@ const (
 
 // https://developer.zendesk.com/api-reference/webhooks/webhooks-api/webhooks/
 type WebhookService struct {
-	client            *client
-	eventHandlers     *WebhookEventHandlers
-	eventHandlerCache map[WebhookEventType]int
+	client *client
 }
 
 type WebhookEventType string
@@ -135,10 +133,12 @@ type WebhookEventHandlers struct {
 	WebhookEventOrganizationNameChanged        func(eventData WebhookEventOrganizationNameChangedPayload) error        ``
 	WebhookEventOrganizationTagsChanged        func(eventData WebhookEventOrganizationTagsChangedPayload) error        ``
 
+	WebhookEventUserAliasChanged                  func(eventData WebhookEventUserAliasChangedPayload) error                  ``
 	WebhookEventUserCreated                       func(eventData WebhookEventUserCreatedPayload) error                       `zenevent:"zen:event-type:user.created"`
 	WebhookEventUserCustomFieldChanged            func(eventData WebhookEventUserCustomFieldChangedPayload) error            `zenevent:"zen:event-type:user.custom_field_changed"`
 	WebhookEventUserCustomRoleChanged             func(eventData WebhookEventUserCustomRoleChangedPayload) error             ``
 	WebhookEventUserDefaultGroupChanged           func(eventData WebhookEventUserDefaultGroupChangedPayload) error           ``
+	WebhookEventUserDetailsChanged                func(eventData WebhookEventUserDetailsChangedPayload) error                ``
 	WebhookEventUserExternalIDChanged             func(eventData WebhookEventUserExternalIDChangedPayload) error             ``
 	WebhookEventUserGroupMembershipCreated        func(eventData WebhookEventUserGroupMembershipCreatedPayload) error        ``
 	WebhookEventUserGroupMembershipDeleted        func(eventData WebhookEventUserGroupMembershipDeletedPayload) error        ``
@@ -199,7 +199,7 @@ type WebhookEvent struct {
 	Detail              any              `json:"detail"`
 }
 
-func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Handler {
+func (s *WebhookService) HandleWebhookEvent(eventHandlers WebhookEventHandlers, webhookSigningSecret string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		webhookBody, err := readWebhookBody(r)
 		if err != nil {
@@ -230,8 +230,9 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 		}
 
 		switch baseTarget.Type {
+		// Article Events
 		case WebhookEventArticlePublished:
-			if s.eventHandlers.WebhookEventArticlePublished != nil {
+			if eventHandlers.WebhookEventArticlePublished != nil {
 				target := WebhookEventArticlePublishedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -239,7 +240,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventArticlePublished(target); err != nil {
+				if err := eventHandlers.WebhookEventArticlePublished(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -250,7 +251,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventArticleSubscriptionCreated:
-			if s.eventHandlers.WebhookEventArticleSubscriptionCreated != nil {
+			if eventHandlers.WebhookEventArticleSubscriptionCreated != nil {
 				target := WebhookEventArticleSubscriptionCreatedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -258,7 +259,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventArticleSubscriptionCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleSubscriptionCreated(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -269,7 +270,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventArticleUnpublished:
-			if s.eventHandlers.WebhookEventArticleUnpublished != nil {
+			if eventHandlers.WebhookEventArticleUnpublished != nil {
 				target := WebhookEventArticleUnpublishedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -277,7 +278,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventArticleUnpublished(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleUnpublished(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -288,7 +289,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventArticleVoteCreated:
-			if s.eventHandlers.WebhookEventArticleVoteCreated != nil {
+			if eventHandlers.WebhookEventArticleVoteCreated != nil {
 				target := WebhookEventArticleVoteCreatedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -296,7 +297,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventArticleVoteCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleVoteCreated(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -307,7 +308,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventArticleVoteChanged:
-			if s.eventHandlers.WebhookEventArticleVoteChanged != nil {
+			if eventHandlers.WebhookEventArticleVoteChanged != nil {
 				target := WebhookEventArticleVoteChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -315,7 +316,26 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventArticleVoteChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleVoteChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventArticleVoteRemoved:
+			if eventHandlers.WebhookEventArticleVoteRemoved != nil {
+				target := WebhookEventArticleVoteRemovedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventArticleVoteRemoved(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -326,7 +346,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventArticleCommentCreated:
-			if s.eventHandlers.WebhookEventArticleCommentCreated != nil {
+			if eventHandlers.WebhookEventArticleCommentCreated != nil {
 				target := WebhookEventArticleCommentCreatedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -334,7 +354,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventArticleCommentCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleCommentCreated(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -345,7 +365,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventArticleCommentChanged:
-			if s.eventHandlers.WebhookEventArticleCommentChanged != nil {
+			if eventHandlers.WebhookEventArticleCommentChanged != nil {
 				target := WebhookEventArticleCommentChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -353,7 +373,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventArticleCommentChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleCommentChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -364,7 +384,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventArticleCommentPublished:
-			if s.eventHandlers.WebhookEventArticleCommentPublished != nil {
+			if eventHandlers.WebhookEventArticleCommentPublished != nil {
 				target := WebhookEventArticleCommentPublishedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -372,7 +392,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventArticleCommentPublished(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleCommentPublished(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -383,7 +403,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventArticleCommentUnpublished:
-			if s.eventHandlers.WebhookEventArticleCommentUnpublished != nil {
+			if eventHandlers.WebhookEventArticleCommentUnpublished != nil {
 				target := WebhookEventArticleCommentUnpublishedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -391,7 +411,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventArticleCommentUnpublished(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleCommentUnpublished(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -401,8 +421,10 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
+
+		// Organization Events
 		case WebhookEventOrganizationCreated:
-			if s.eventHandlers.WebhookEventOrganizationCreated != nil {
+			if eventHandlers.WebhookEventOrganizationCreated != nil {
 				target := WebhookEventOrganizationCreatedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -410,7 +432,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventOrganizationCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventOrganizationCreated(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -421,7 +443,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventOrganizationCustomFieldChanged:
-			if s.eventHandlers.WebhookEventOrganizationCustomFieldChanged != nil {
+			if eventHandlers.WebhookEventOrganizationCustomFieldChanged != nil {
 				target := WebhookEventOrganizationCustomFieldChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -429,7 +451,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventOrganizationCustomFieldChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventOrganizationCustomFieldChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -440,7 +462,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventOrganizationDeleted:
-			if s.eventHandlers.WebhookEventOrganizationDeleted != nil {
+			if eventHandlers.WebhookEventOrganizationDeleted != nil {
 				target := WebhookEventOrganizationDeletedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -448,7 +470,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventOrganizationDeleted(target); err != nil {
+				if err := eventHandlers.WebhookEventOrganizationDeleted(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -458,16 +480,16 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
-		case WebhookEventUserLastLoginChanged:
-			if s.eventHandlers.WebhookEventUserLastLoginChanged != nil {
-				target := WebhookEventUserLastLoginChangedPayload{}
+		case WebhookEventOrganizationExternalIDChanged:
+			if eventHandlers.WebhookEventOrganizationExternalIDChanged != nil {
+				target := WebhookEventOrganizationExternalIDChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserLastLoginChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventOrganizationExternalIDChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -477,16 +499,16 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
-		case WebhookEventUserMerged:
-			if s.eventHandlers.WebhookEventUserMerged != nil {
-				target := WebhookEventUserMergedPayload{}
+		case WebhookEventOrganizationNameChanged:
+			if eventHandlers.WebhookEventOrganizationNameChanged != nil {
+				target := WebhookEventOrganizationNameChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserMerged(target); err != nil {
+				if err := eventHandlers.WebhookEventOrganizationNameChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -496,16 +518,16 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
-		case WebhookEventUserNameChanged:
-			if s.eventHandlers.WebhookEventUserNameChanged != nil {
-				target := WebhookEventUserNameChangedPayload{}
+		case WebhookEventOrganizationTagsChanged:
+			if eventHandlers.WebhookEventOrganizationTagsChanged != nil {
+				target := WebhookEventOrganizationTagsChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserNameChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventOrganizationTagsChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -515,16 +537,18 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
-		case WebhookEventUserNotesChanged:
-			if s.eventHandlers.WebhookEventUserNotesChanged != nil {
-				target := WebhookEventUserNotesChangedPayload{}
+
+		// User Events
+		case WebhookEventUserAliasChanged:
+			if eventHandlers.WebhookEventUserAliasChanged != nil {
+				target := WebhookEventUserAliasChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserNotesChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserAliasChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -534,16 +558,16 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
-		case WebhookEventUserOnlyPrivateCommentsChanged:
-			if s.eventHandlers.WebhookEventUserOnlyPrivateCommentsChanged != nil {
-				target := WebhookEventUserOnlyPrivateCommentsChangedPayload{}
+		case WebhookEventUserCreated:
+			if eventHandlers.WebhookEventUserCreated != nil {
+				target := WebhookEventUserCreatedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserOnlyPrivateCommentsChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserCreated(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -553,16 +577,16 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
-		case WebhookEventUserOrganizationMembershipCreated:
-			if s.eventHandlers.WebhookEventUserOrganizationMembershipCreated != nil {
-				target := WebhookEventUserOrganizationMembershipCreatedPayload{}
+		case WebhookEventUserCustomFieldChanged:
+			if eventHandlers.WebhookEventUserCustomFieldChanged != nil {
+				target := WebhookEventUserCustomFieldChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserOrganizationMembershipCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventUserCustomFieldChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -572,16 +596,16 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
-		case WebhookEventUserOrganizationMembershipDeleted:
-			if s.eventHandlers.WebhookEventUserOrganizationMembershipDeleted != nil {
-				target := WebhookEventUserOrganizationMembershipDeletedPayload{}
+		case WebhookEventUserCustomRoleChanged:
+			if eventHandlers.WebhookEventUserCustomRoleChanged != nil {
+				target := WebhookEventUserCustomRoleChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserOrganizationMembershipDeleted(target); err != nil {
+				if err := eventHandlers.WebhookEventUserCustomRoleChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -591,16 +615,16 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
-		case WebhookEventUserPasswordChanged:
-			if s.eventHandlers.WebhookEventUserPasswordChanged != nil {
-				target := WebhookEventUserPasswordChangedPayload{}
+		case WebhookEventUserDefaultGroupChanged:
+			if eventHandlers.WebhookEventUserDefaultGroupChanged != nil {
+				target := WebhookEventUserDefaultGroupChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserPasswordChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserDefaultGroupChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -610,16 +634,16 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
-		case WebhookEventUserPhotoChanged:
-			if s.eventHandlers.WebhookEventUserPhotoChanged != nil {
-				target := WebhookEventUserPhotoChangedPayload{}
+		case WebhookEventUserDetailsChanged:
+			if eventHandlers.WebhookEventUserDetailsChanged != nil {
+				target := WebhookEventUserDetailsChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserPhotoChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserDetailsChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -629,16 +653,16 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
-		case WebhookEventUserRoleChanged:
-			if s.eventHandlers.WebhookEventUserRoleChanged != nil {
-				target := WebhookEventUserRoleChangedPayload{}
+		case WebhookEventUserExternalIDChanged:
+			if eventHandlers.WebhookEventUserExternalIDChanged != nil {
+				target := WebhookEventUserExternalIDChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserRoleChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserExternalIDChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -648,16 +672,92 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
-		case WebhookEventUserDeleted:
-			if s.eventHandlers.WebhookEventUserDeleted != nil {
-				target := WebhookEventUserDeletedPayload{}
+		case WebhookEventUserGroupMembershipCreated:
+			if eventHandlers.WebhookEventUserGroupMembershipCreated != nil {
+				target := WebhookEventUserGroupMembershipCreatedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserDeleted(target); err != nil {
+				if err := eventHandlers.WebhookEventUserGroupMembershipCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserGroupMembershipDeleted:
+			if eventHandlers.WebhookEventUserGroupMembershipDeleted != nil {
+				target := WebhookEventUserGroupMembershipDeletedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserGroupMembershipDeleted(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserIdentityChanged:
+			if eventHandlers.WebhookEventUserIdentityChanged != nil {
+				target := WebhookEventUserIdentityChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserIdentityChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserIdentityCreated:
+			if eventHandlers.WebhookEventUserIdentityCreated != nil {
+				target := WebhookEventUserIdentityCreatedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserIdentityCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserIdentityDeleted:
+			if eventHandlers.WebhookEventUserIdentityDeleted != nil {
+				target := WebhookEventUserIdentityDeletedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserIdentityDeleted(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -668,7 +768,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventUserActiveChanged:
-			if s.eventHandlers.WebhookEventUserActiveChanged != nil {
+			if eventHandlers.WebhookEventUserActiveChanged != nil {
 				target := WebhookEventUserActiveChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -676,7 +776,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserActiveChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserActiveChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -686,8 +786,218 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
+		case WebhookEventUserLastLoginChanged:
+			if eventHandlers.WebhookEventUserLastLoginChanged != nil {
+				target := WebhookEventUserLastLoginChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserLastLoginChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserMerged:
+			if eventHandlers.WebhookEventUserMerged != nil {
+				target := WebhookEventUserMergedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserMerged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserNameChanged:
+			if eventHandlers.WebhookEventUserNameChanged != nil {
+				target := WebhookEventUserNameChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserNameChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserNotesChanged:
+			if eventHandlers.WebhookEventUserNotesChanged != nil {
+				target := WebhookEventUserNotesChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserNotesChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserOnlyPrivateCommentsChanged:
+			if eventHandlers.WebhookEventUserOnlyPrivateCommentsChanged != nil {
+				target := WebhookEventUserOnlyPrivateCommentsChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserOnlyPrivateCommentsChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserOrganizationMembershipCreated:
+			if eventHandlers.WebhookEventUserOrganizationMembershipCreated != nil {
+				target := WebhookEventUserOrganizationMembershipCreatedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserOrganizationMembershipCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserOrganizationMembershipDeleted:
+			if eventHandlers.WebhookEventUserOrganizationMembershipDeleted != nil {
+				target := WebhookEventUserOrganizationMembershipDeletedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserOrganizationMembershipDeleted(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserPasswordChanged:
+			if eventHandlers.WebhookEventUserPasswordChanged != nil {
+				target := WebhookEventUserPasswordChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserPasswordChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserPhotoChanged:
+			if eventHandlers.WebhookEventUserPhotoChanged != nil {
+				target := WebhookEventUserPhotoChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserPhotoChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserRoleChanged:
+			if eventHandlers.WebhookEventUserRoleChanged != nil {
+				target := WebhookEventUserRoleChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserRoleChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserDeleted:
+			if eventHandlers.WebhookEventUserDeleted != nil {
+				target := WebhookEventUserDeletedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := eventHandlers.WebhookEventUserDeleted(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+
 		case WebhookEventUserSuspendedChanged:
-			if s.eventHandlers.WebhookEventUserSuspendedChanged != nil {
+			if eventHandlers.WebhookEventUserSuspendedChanged != nil {
 				target := WebhookEventUserSuspendedChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -695,7 +1005,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserSuspendedChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserSuspendedChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -706,7 +1016,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventUserTagsChanged:
-			if s.eventHandlers.WebhookEventUserTagsChanged != nil {
+			if eventHandlers.WebhookEventUserTagsChanged != nil {
 				target := WebhookEventUserTagsChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -714,7 +1024,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserTagsChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserTagsChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -725,7 +1035,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventUserTimeZoneChanged:
-			if s.eventHandlers.WebhookEventUserTimeZoneChanged != nil {
+			if eventHandlers.WebhookEventUserTimeZoneChanged != nil {
 				target := WebhookEventUserTimeZoneChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -733,7 +1043,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventUserTimeZoneChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserTimeZoneChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -743,8 +1053,10 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
+
+		// Community Post Events
 		case WebhookEventCommunityPostCreated:
-			if s.eventHandlers.WebhookEventCommunityPostCreated != nil {
+			if eventHandlers.WebhookEventCommunityPostCreated != nil {
 				target := WebhookEventCommunityPostCreatedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -752,7 +1064,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCreated(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -763,7 +1075,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventCommunityPostChanged:
-			if s.eventHandlers.WebhookEventCommunityPostChanged != nil {
+			if eventHandlers.WebhookEventCommunityPostChanged != nil {
 				target := WebhookEventCommunityPostChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -771,7 +1083,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -782,7 +1094,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventCommunityPostPublished:
-			if s.eventHandlers.WebhookEventCommunityPostPublished != nil {
+			if eventHandlers.WebhookEventCommunityPostPublished != nil {
 				target := WebhookEventCommunityPostPublishedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -790,7 +1102,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostPublished(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostPublished(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -801,7 +1113,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventCommunityPostUnpublished:
-			if s.eventHandlers.WebhookEventCommunityPostUnpublished != nil {
+			if eventHandlers.WebhookEventCommunityPostUnpublished != nil {
 				target := WebhookEventCommunityPostUnpublishedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -809,7 +1121,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostUnpublished(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostUnpublished(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -820,7 +1132,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventCommunityPostSubscriptionCreated:
-			if s.eventHandlers.WebhookEventCommunityPostSubscriptionCreated != nil {
+			if eventHandlers.WebhookEventCommunityPostSubscriptionCreated != nil {
 				target := WebhookEventCommunityPostSubscriptionCreatedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -828,7 +1140,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostSubscriptionCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostSubscriptionCreated(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -839,7 +1151,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventCommunityPostVoteCreated:
-			if s.eventHandlers.WebhookEventCommunityPostVoteCreated != nil {
+			if eventHandlers.WebhookEventCommunityPostVoteCreated != nil {
 				target := WebhookEventCommunityPostVoteCreatedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -847,7 +1159,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostVoteCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostVoteCreated(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -858,7 +1170,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventCommunityPostVoteChanged:
-			if s.eventHandlers.WebhookEventCommunityPostVoteChanged != nil {
+			if eventHandlers.WebhookEventCommunityPostVoteChanged != nil {
 				target := WebhookEventCommunityPostVoteChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -866,7 +1178,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostVoteChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostVoteChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -877,7 +1189,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventCommunityPostVoteRemoved:
-			if s.eventHandlers.WebhookEventCommunityPostVoteRemoved != nil {
+			if eventHandlers.WebhookEventCommunityPostVoteRemoved != nil {
 				target := WebhookEventCommunityPostVoteRemovedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -885,7 +1197,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostVoteRemoved(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostVoteRemoved(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -896,7 +1208,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventCommunityPostCommentCreated:
-			if s.eventHandlers.WebhookEventCommunityPostCommentCreated != nil {
+			if eventHandlers.WebhookEventCommunityPostCommentCreated != nil {
 				target := WebhookEventCommunityPostCommentCreatedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -904,7 +1216,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostCommentCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCommentCreated(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -915,7 +1227,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventCommunityPostCommentChanged:
-			if s.eventHandlers.WebhookEventCommunityPostCommentChanged != nil {
+			if eventHandlers.WebhookEventCommunityPostCommentChanged != nil {
 				target := WebhookEventCommunityPostCommentChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -923,7 +1235,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostCommentChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCommentChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -934,7 +1246,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventCommunityPostCommentPublished:
-			if s.eventHandlers.WebhookEventCommunityPostCommentPublished != nil {
+			if eventHandlers.WebhookEventCommunityPostCommentPublished != nil {
 				target := WebhookEventCommunityPostCommentPublishedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -942,7 +1254,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostCommentPublished(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCommentPublished(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -953,7 +1265,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventCommunityPostCommentUnpublished:
-			if s.eventHandlers.WebhookEventCommunityPostCommentUnpublished != nil {
+			if eventHandlers.WebhookEventCommunityPostCommentUnpublished != nil {
 				target := WebhookEventCommunityPostCommentUnpublishedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -961,7 +1273,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostCommentUnpublished(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCommentUnpublished(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -972,7 +1284,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventCommunityPostCommentVoteCreated:
-			if s.eventHandlers.WebhookEventCommunityPostCommentVoteCreated != nil {
+			if eventHandlers.WebhookEventCommunityPostCommentVoteCreated != nil {
 				target := WebhookEventCommunityPostCommentVoteCreatedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -980,7 +1292,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostCommentVoteCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCommentVoteCreated(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -991,7 +1303,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventCommunityPostCommentVoteChanged:
-			if s.eventHandlers.WebhookEventCommunityPostCommentVoteChanged != nil {
+			if eventHandlers.WebhookEventCommunityPostCommentVoteChanged != nil {
 				target := WebhookEventCommunityPostCommentVoteChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -999,7 +1311,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventCommunityPostCommentVoteChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCommentVoteChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1009,8 +1321,10 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
+
+		// Agent State Events
 		case WebhookEventAgentStateChanged:
-			if s.eventHandlers.WebhookEventAgentStateChanged != nil {
+			if eventHandlers.WebhookEventAgentStateChanged != nil {
 				target := WebhookEventAgentStateChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -1018,7 +1332,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventAgentStateChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentStateChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1029,7 +1343,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventAgentWorkItemAdded:
-			if s.eventHandlers.WebhookEventAgentWorkItemAdded != nil {
+			if eventHandlers.WebhookEventAgentWorkItemAdded != nil {
 				target := WebhookEventAgentWorkItemAddedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -1037,7 +1351,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventAgentWorkItemAdded(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentWorkItemAdded(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1048,7 +1362,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventAgentWorkItemRemoved:
-			if s.eventHandlers.WebhookEventAgentWorkItemRemoved != nil {
+			if eventHandlers.WebhookEventAgentWorkItemRemoved != nil {
 				target := WebhookEventAgentWorkItemRemovedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -1056,7 +1370,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventAgentWorkItemRemoved(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentWorkItemRemoved(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1067,7 +1381,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventAgentMaxCapacityChanged:
-			if s.eventHandlers.WebhookEventAgentMaxCapacityChanged != nil {
+			if eventHandlers.WebhookEventAgentMaxCapacityChanged != nil {
 				target := WebhookEventAgentMaxCapacityChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -1075,7 +1389,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventAgentMaxCapacityChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentMaxCapacityChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1086,7 +1400,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventAgentUnifiedStateChanged:
-			if s.eventHandlers.WebhookEventAgentUnifiedStateChanged != nil {
+			if eventHandlers.WebhookEventAgentUnifiedStateChanged != nil {
 				target := WebhookEventAgentUnifiedStateChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -1094,7 +1408,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventAgentUnifiedStateChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentUnifiedStateChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1105,7 +1419,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventAgentChannelCreated:
-			if s.eventHandlers.WebhookEventAgentChannelCreated != nil {
+			if eventHandlers.WebhookEventAgentChannelCreated != nil {
 				target := WebhookEventAgentChannelCreatedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -1113,7 +1427,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventAgentChannelCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentChannelCreated(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1124,7 +1438,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 				}
 			}
 		case WebhookEventAgentChannelDeleted:
-			if s.eventHandlers.WebhookEventAgentChannelDeleted != nil {
+			if eventHandlers.WebhookEventAgentChannelDeleted != nil {
 				target := WebhookEventAgentChannelDeletedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -1132,7 +1446,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventAgentChannelDeleted(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentChannelDeleted(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1142,8 +1456,10 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 			}
+
+		// Omnichannel Routing Configuration Events
 		case WebhookEventOmnichannelRoutingConfigFeatureChanged:
-			if s.eventHandlers.WebhookEventOmnichannelRoutingConfigFeatureChanged != nil {
+			if eventHandlers.WebhookEventOmnichannelRoutingConfigFeatureChanged != nil {
 				target := WebhookEventOmnichannelRoutingConfigFeatureChangedPayload{}
 				if err := json.Unmarshal(webhookBody, &target); err != nil {
 					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
@@ -1151,7 +1467,7 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 					return
 				}
 
-				if err := s.eventHandlers.WebhookEventOmnichannelRoutingConfigFeatureChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventOmnichannelRoutingConfigFeatureChanged(target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1176,9 +1492,32 @@ func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Ha
 	)
 }
 
-func (s *WebhookService) WebhookTriggerHandler(handler func(b []byte), secret string) http.Handler {
+func (s *WebhookService) HandleWebhookTrigger(handler func(b []byte) error, webhookSigningSecret string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		webhookBody, err := readWebhookBody(r)
+		if err != nil {
+			respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
+			return
+		}
+
+		if webhookSigningSecret != "" {
+			if !s.verifyZendeskWebhookSignatureIsValid(r, webhookBody, webhookSigningSecret) {
+				respondToWebhookRequest(w, http.StatusBadRequest, "Bad Request")
+
+				return
+			}
+		}
+
+		if handler != nil {
+			if err := handler(webhookBody); err != nil {
+				respondToWebhookRequest(w, http.StatusInternalServerError, err.Error())
+
+				return
+			}
+		}
+
+		respondToWebhookRequest(w, http.StatusOK, "Success")
 	})
 }
 
@@ -1264,8 +1603,6 @@ type WebhookCommunityPostEventData interface {
 	any
 }
 
-type WebhookEventArticleAuthorChangedPayload WebhookEventArticle[EventTypeArticleAuthorChangedEvent]
-
 type EventTypeArticleAuthorChangedEvent struct {
 }
 
@@ -1281,14 +1618,14 @@ type WebhookEventUser[EventData WebhookUserEventData] struct {
 }
 
 type WebhookEventUserDetail struct {
-	CreatedAt      time.Time    `json:"created_at"`
-	Email          string       `json:"email"`
-	ExternalID     string       `json:"external_id"`
-	DefaultGroupID string       `json:"default_group_id"`
-	ID             string       `json:"id"`
-	OrganizationID string       `json:"organization_id"`
-	Role           CustomRoleID `json:"role"`
-	UpdatedAt      time.Time    `json:"updated_at"`
+	CreatedAt      time.Time `json:"created_at"`
+	Email          string    `json:"email"`
+	ExternalID     string    `json:"external_id"`
+	DefaultGroupID string    `json:"default_group_id"`
+	ID             string    `json:"id"`
+	OrganizationID string    `json:"organization_id"`
+	Role           string    `json:"role"`
+	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 type WebhookUserEventData interface {
@@ -1301,11 +1638,6 @@ type WebhookUserEventData interface {
 type WebhookEventUserActiveStatusChangedPayload struct {
 	Current  bool `json:"current"`
 	Previous bool `json:"previous"`
-}
-
-type WebhookEventUserDetailsChangedPayload struct {
-	Current  string `json:"current"`
-	Previous string `json:"previous"`
 }
 
 // https://developer.zendesk.com/api-reference/webhooks/event-types/community-events/#detail-object-properties
@@ -1340,7 +1672,7 @@ func (s WebhookService) verifyZendeskWebhookSignatureIsValid(
 	}
 
 	actualZendeskSignature := buildZendeskSignature(zendeskSignatureTimestamp, bodyBytes, webhookSigningSecret)
-	return expectedZendeskSignature != actualZendeskSignature
+	return expectedZendeskSignature == actualZendeskSignature
 }
 
 func buildZendeskSignature(
@@ -1380,39 +1712,107 @@ func readWebhookBody(r *http.Request) ([]byte, error) {
 	return bodyBytes, nil
 }
 
-type WebhookEventUserAliasChangedPayload WebhookEventUser[any]
-type WebhookEventUserCreatedPayload WebhookEventUser[any]
-type WebhookEventUserCustomFieldChangedPayload WebhookEventUser[any]
-type WebhookEventUserCustomRoleChangedPayload WebhookEventUser[any]
-type WebhookEventUserDefaultGroupChangedPayload WebhookEventUser[any]
-type WebhookEventUserExternalIDChangedPayload WebhookEventUser[any]
-type WebhookEventUserGroupMembershipCreatedPayload WebhookEventUser[any]
-type WebhookEventUserGroupMembershipDeletedPayload WebhookEventUser[any]
-type WebhookEventUserIdentityChangedPayload WebhookEventUser[any]
-type WebhookEventUserIdentityCreatedPayload WebhookEventUser[any]
-type WebhookEventUserIdentityDeletedPayload WebhookEventUser[any]
-type WebhookEventUserActiveChangedPayload WebhookEventUser[any]
-type WebhookEventUserLastLoginChangedPayload WebhookEventUser[any]
-type WebhookEventUserMergedPayload WebhookEventUser[any]
-type WebhookEventUserNameChangedPayload WebhookEventUser[any]
-type WebhookEventUserNotesChangedPayload WebhookEventUser[any]
-type WebhookEventUserOnlyPrivateCommentsChangedPayload WebhookEventUser[any]
-type WebhookEventUserOrganizationMembershipCreatedPayload WebhookEventUser[any]
-type WebhookEventUserOrganizationMembershipDeletedPayload WebhookEventUser[any]
-type WebhookEventUserPasswordChangedPayload WebhookEventUser[any]
-type WebhookEventUserPhotoChangedPayload WebhookEventUser[any]
-type WebhookEventUserRoleChangedPayload WebhookEventUser[any]
-type WebhookEventUserDeletedPayload WebhookEventUser[any]
-type WebhookEventUserSuspendedChangedPayload WebhookEventUser[any]
-type WebhookEventUserTagsChangedPayload WebhookEventUser[any]
-type WebhookEventUserTimeZoneChangedPayload WebhookEventUser[any]
+type WebhookEventDataUserIdentitySchema struct {
+	ID      string `json:"id"`
+	Primary bool   `json:"primary"`
+	Type    string `json:"type"`
+	Value   string `json:"value"`
+}
 
-type WebhookEventOrganizationCreatedPayload WebhookEventOrganization[any]
-type WebhookEventOrganizationCustomFieldChangedPayload WebhookEventOrganization[any]
-type WebhookEventOrganizationDeletedPayload WebhookEventOrganization[any]
-type WebhookEventOrganizationExternalIDChangedPayload WebhookEventOrganization[any]
-type WebhookEventOrganizationNameChangedPayload WebhookEventOrganization[any]
-type WebhookEventOrganizationTagsChangedPayload WebhookEventOrganization[any]
+type WebhookEventDataSimpleStringUpdate struct {
+	Current  string `json:"current"`
+	Previous string `json:"previous"`
+}
+
+type WebhookEventDataSimpleBoolUpdate struct {
+	Current  bool `json:"current"`
+	Previous bool `json:"previous"`
+}
+
+type WebhookEventDataEmpty struct{}
+
+type WebhookEventDataCustomFieldUpdate struct {
+	Current  any `json:"current"`
+	Previous any `json:"previous"`
+	Field    struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+		Type  string `json:"type"`
+	} `json:"field"`
+}
+
+type WebhookEventDataUserGroupMembershipChanged struct {
+	Group WebhookEventDataIDField `json:"group"`
+}
+
+type WebhookEventDataIDField struct {
+	ID string `json:"id"`
+}
+
+type WebhookEventDataUserIdentityChanged struct {
+	Current  WebhookEventDataUserIdentitySchema `json:"current"`
+	Previous WebhookEventDataUserIdentitySchema `json:"previous"`
+}
+
+type WebhookEventDataUserIdentity struct {
+	Identity WebhookEventDataUserIdentitySchema `json:"current"`
+}
+
+type WebhookEventDataUserMerged struct {
+	User struct {
+		ID string `json:"id"`
+	} `json:"user"`
+}
+
+type WebhookEventDataUserOrganizationMembershipChanged struct {
+	Organization struct {
+		ID string `json:"id"`
+	} `json:"organization"`
+}
+
+type WebhookEventDataTagsChanged struct {
+	Added struct {
+		Tags []string `json:"tags"`
+	} `json:"added"`
+	Removed struct {
+		Tags []string `json:"tags"`
+	} `json:"removed"`
+}
+
+type WebhookEventUserAliasChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+type WebhookEventUserCreatedPayload WebhookEventUser[WebhookEventDataEmpty]
+type WebhookEventUserCustomFieldChangedPayload WebhookEventUser[WebhookEventDataCustomFieldUpdate]
+type WebhookEventUserCustomRoleChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+type WebhookEventUserDefaultGroupChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+type WebhookEventUserDetailsChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+type WebhookEventUserExternalIDChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+type WebhookEventUserGroupMembershipCreatedPayload WebhookEventUser[WebhookEventDataUserGroupMembershipChanged]
+type WebhookEventUserGroupMembershipDeletedPayload WebhookEventUser[WebhookEventDataUserGroupMembershipChanged]
+type WebhookEventUserIdentityChangedPayload WebhookEventUser[WebhookEventDataUserIdentityChanged]
+type WebhookEventUserIdentityCreatedPayload WebhookEventUser[WebhookEventDataUserIdentity]
+type WebhookEventUserIdentityDeletedPayload WebhookEventUser[WebhookEventDataUserIdentity]
+type WebhookEventUserActiveChangedPayload WebhookEventUser[WebhookEventDataSimpleBoolUpdate]
+type WebhookEventUserLastLoginChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+type WebhookEventUserMergedPayload WebhookEventUser[WebhookEventDataUserMerged]
+type WebhookEventUserNameChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+type WebhookEventUserNotesChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+type WebhookEventUserOnlyPrivateCommentsChangedPayload WebhookEventUser[WebhookEventDataSimpleBoolUpdate]
+type WebhookEventUserOrganizationMembershipCreatedPayload WebhookEventUser[WebhookEventDataUserOrganizationMembershipChanged]
+type WebhookEventUserOrganizationMembershipDeletedPayload WebhookEventUser[WebhookEventDataUserOrganizationMembershipChanged]
+type WebhookEventUserPasswordChangedPayload WebhookEventUser[WebhookEventDataEmpty]
+type WebhookEventUserPhotoChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+type WebhookEventUserRoleChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+type WebhookEventUserDeletedPayload WebhookEventUser[WebhookEventDataEmpty]
+type WebhookEventUserSuspendedChangedPayload WebhookEventUser[WebhookEventDataSimpleBoolUpdate]
+type WebhookEventUserTagsChangedPayload WebhookEventUser[WebhookEventDataTagsChanged]
+type WebhookEventUserTimeZoneChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+
+type WebhookEventOrganizationCreatedPayload WebhookEventOrganization[WebhookEventDataEmpty]
+type WebhookEventOrganizationCustomFieldChangedPayload WebhookEventOrganization[WebhookEventDataCustomFieldUpdate]
+type WebhookEventOrganizationDeletedPayload WebhookEventOrganization[WebhookEventDataEmpty]
+type WebhookEventOrganizationExternalIDChangedPayload WebhookEventOrganization[WebhookEventDataSimpleStringUpdate]
+type WebhookEventOrganizationNameChangedPayload WebhookEventOrganization[WebhookEventDataSimpleStringUpdate]
+type WebhookEventOrganizationTagsChangedPayload WebhookEventOrganization[WebhookEventDataTagsChanged]
 
 type WebhookEventArticlePublishedPayload WebhookEventArticle[any]
 type WebhookEventArticleSubscriptionCreatedPayload WebhookEventArticle[any]
@@ -1424,6 +1824,7 @@ type WebhookEventArticleCommentCreatedPayload WebhookEventArticle[any]
 type WebhookEventArticleCommentChangedPayload WebhookEventArticle[any]
 type WebhookEventArticleCommentPublishedPayload WebhookEventArticle[any]
 type WebhookEventArticleCommentUnpublishedPayload WebhookEventArticle[any]
+type WebhookEventArticleAuthorChangedPayload WebhookEventArticle[any]
 
 type WebhookEventCommunityPostCreatedPayload WebhookEventCommunityPost[any]
 type WebhookEventCommunityPostChangedPayload WebhookEventCommunityPost[any]

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -1,0 +1,29 @@
+package zendesk
+
+import "time"
+
+type WebhookEventType string
+
+const (
+	WebhookEventUserActive WebhookEventType = "zen:event-type:user.active_changed"
+	// Other webhook events...
+)
+
+type WebhookEvent struct {
+	Type                WebhookEventType `json:"type"`
+	AccountID           AccountID        `json:"account_id"`
+	ID                  WebhookEventID   `json:"id"`
+	Time                time.Time        `json:"time"`
+	ZendeskEventVersion string           `json:"zendesk_event_version"`
+	Subject             string           `json:"subject"`
+	Detail              any              `json:"detail"`
+	Event               any              `json:"event"`
+}
+
+type WebhookEventDetailArticle struct {
+	BrandID BrandID   `json:"brand_id"`
+	ID      ArticleID `json:"id"`
+}
+
+type WebhookEventEvent struct {
+}

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -19,120 +19,1328 @@ const (
 
 // https://developer.zendesk.com/api-reference/webhooks/webhooks-api/webhooks/
 type WebhookService struct {
-	client *client
+	client            *client
+	eventHandlers     *WebhookEventHandlers
+	eventHandlerCache map[WebhookEventType]int
 }
 
 type WebhookEventType string
 
+// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/
 const (
-	WebhookEventUserActive               WebhookEventType = "zen:event-type:user.active_changed"
-	WebhookEventOmnichannelConfigFeature WebhookEventType = "zen:event-type:omnichannel_config.omnichannel_routing_feature_changed"
-	// Other webhook events...
+	WebhookEventArticleAuthorChanged       WebhookEventType = "zen:event-type:article.author_changed"
+	WebhookEventArticlePublished           WebhookEventType = "zen:event-type:article.published"
+	WebhookEventArticleSubscriptionCreated WebhookEventType = "zen:event-type:article.subscription_created"
+	WebhookEventArticleUnpublished         WebhookEventType = "zen:event-type:article.unpublished"
+	WebhookEventArticleVoteCreated         WebhookEventType = "zen:event-type:article.vote_created"
+	WebhookEventArticleVoteChanged         WebhookEventType = "zen:event-type:article.vote_changed"
+	WebhookEventArticleVoteRemoved         WebhookEventType = "zen:event-type:article.vote_removed"
+	WebhookEventArticleCommentCreated      WebhookEventType = "zen:event-type:article.comment_created"
+	WebhookEventArticleCommentChanged      WebhookEventType = "zen:event-type:article.comment_changed"
+	WebhookEventArticleCommentPublished    WebhookEventType = "zen:event-type:article.comment_published"
+	WebhookEventArticleCommentUnpublished  WebhookEventType = "zen:event-type:article.comment_unpublished"
+)
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/community-events/
+const (
+	WebhookEventCommunityPostCreated             WebhookEventType = "zen:event-type:community_post.created"
+	WebhookEventCommunityPostChanged             WebhookEventType = "zen:event-type:community_post.changed"
+	WebhookEventCommunityPostPublished           WebhookEventType = "zen:event-type:community_post.published"
+	WebhookEventCommunityPostUnpublished         WebhookEventType = "zen:event-type:community_post.unpublished"
+	WebhookEventCommunityPostSubscriptionCreated WebhookEventType = "zen:event-type:community_post.subscription_created"
+	WebhookEventCommunityPostVoteCreated         WebhookEventType = "zen:event-type:community_post.vote_created"
+	WebhookEventCommunityPostVoteChanged         WebhookEventType = "zen:event-type:community_post.vote_changed"
+	WebhookEventCommunityPostVoteRemoved         WebhookEventType = "zen:event-type:community_post.vote_removed"
+	WebhookEventCommunityPostCommentCreated      WebhookEventType = "zen:event-type:community_post.comment_created"
+	WebhookEventCommunityPostCommentChanged      WebhookEventType = "zen:event-type:community_post.comment_changed"
+	WebhookEventCommunityPostCommentPublished    WebhookEventType = "zen:event-type:community_post.comment_published"
+	WebhookEventCommunityPostCommentUnpublished  WebhookEventType = "zen:event-type:community_post.comment_unpublished"
+	WebhookEventCommunityPostCommentVoteCreated  WebhookEventType = "zen:event-type:community_post.comment_vote_created"
+	WebhookEventCommunityPostCommentVoteChanged  WebhookEventType = "zen:event-type:community_post.comment_vote_changed"
+)
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/organization-events/
+const (
+	WebhookEventOrganizationCreated            WebhookEventType = "zen:event-type:organization.created"
+	WebhookEventOrganizationCustomFieldChanged WebhookEventType = "zen:event-type:organization.custom_field_changed"
+	WebhookEventOrganizationDeleted            WebhookEventType = "zen:event-type:organization.deleted"
+	WebhookEventOrganizationExternalIDChanged  WebhookEventType = "zen:event-type:organization.external_id_changed"
+	WebhookEventOrganizationNameChanged        WebhookEventType = "zen:event-type:organization.name_changed"
+	WebhookEventOrganizationTagsChanged        WebhookEventType = "zen:event-type:organization.tags_changed"
+)
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/user-events
+const (
+	WebhookEventUserAliasChanged                  WebhookEventType = "zen:event-type:user.alias_changed"
+	WebhookEventUserCreated                       WebhookEventType = "zen:event-type:user.created"
+	WebhookEventUserCustomFieldChanged            WebhookEventType = "zen:event-type:user.custom_field_changed"
+	WebhookEventUserCustomRoleChanged             WebhookEventType = "zen:event-type:user.custom_role_changed"
+	WebhookEventUserDefaultGroupChanged           WebhookEventType = "zen:event-type:user.default_group_changed"
+	WebhookEventUserDetailsChanged                WebhookEventType = "zen:event-type:user.details_changed"
+	WebhookEventUserExternalIDChanged             WebhookEventType = "zen:event-type:user.external_id_changed"
+	WebhookEventUserGroupMembershipCreated        WebhookEventType = "zen:event-type:user.group_membership_created"
+	WebhookEventUserGroupMembershipDeleted        WebhookEventType = "zen:event-type:user.group_membership_deleted"
+	WebhookEventUserIdentityChanged               WebhookEventType = "zen:event-type:user.identity_changed"
+	WebhookEventUserIdentityCreated               WebhookEventType = "zen:event-type:user.identity_created"
+	WebhookEventUserIdentityDeleted               WebhookEventType = "zen:event-type:user.identity_deleted"
+	WebhookEventUserActiveChanged                 WebhookEventType = "zen:event-type:user.active_changed"
+	WebhookEventUserLastLoginChanged              WebhookEventType = "zen:event-type:user.last_login_changed"
+	WebhookEventUserMerged                        WebhookEventType = "zen:event-type:user.merged"
+	WebhookEventUserNameChanged                   WebhookEventType = "zen:event-type:user.name_changed"
+	WebhookEventUserNotesChanged                  WebhookEventType = "zen:event-type:user.notes_changed"
+	WebhookEventUserOnlyPrivateCommentsChanged    WebhookEventType = "zen:event-type:user.only_private_comments_changed"
+	WebhookEventUserOrganizationMembershipCreated WebhookEventType = "zen:event-type:user.organization_membership_created"
+	WebhookEventUserOrganizationMembershipDeleted WebhookEventType = "zen:event-type:user.organization_membership_deleted"
+	WebhookEventUserPasswordChanged               WebhookEventType = "zen:event-type:user.password_changed"
+	WebhookEventUserPhotoChanged                  WebhookEventType = "zen:event-type:user.photo_changed"
+	WebhookEventUserRoleChanged                   WebhookEventType = "zen:event-type:user.role_changed"
+	WebhookEventUserDeleted                       WebhookEventType = "zen:event-type:user.deleted"
+	WebhookEventUserSuspendedChanged              WebhookEventType = "zen:event-type:user.suspended_changed"
+	WebhookEventUserTagsChanged                   WebhookEventType = "zen:event-type:user.tags_changed"
+	WebhookEventUserTimeZoneChanged               WebhookEventType = "zen:event-type:user.time_zone_changed"
+)
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/agent-availability-events/
+const (
+	WebhookEventAgentStateChanged        WebhookEventType = "zen:event-type:agent.state_changed"
+	WebhookEventAgentWorkItemAdded       WebhookEventType = "zen:event-type:agent.work_item_added"
+	WebhookEventAgentWorkItemRemoved     WebhookEventType = "zen:event-type:agent.work_item_removed"
+	WebhookEventAgentMaxCapacityChanged  WebhookEventType = "zen:event-type:agent.max_capacity_changed"
+	WebhookEventAgentUnifiedStateChanged WebhookEventType = "zen:event-type:agent.unified_state_changed"
+	WebhookEventAgentChannelCreated      WebhookEventType = "zen:event-type:agent.channel_created"
+	WebhookEventAgentChannelDeleted      WebhookEventType = "zen:event-type:agent.channel_deleted"
+)
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/omnichannel-routing-configuration-events/
+const (
+	WebhookEventOmnichannelRoutingConfigFeatureChanged WebhookEventType = "zen:event-type:omnichannel_config.omnichannel_routing_feature_changed"
 )
 
 type WebhookEventHandlers struct {
-	WebhookEventArticleAuthorChanged func(event WebhookEventArticleAuthorChanged)
+	WebhookEventArticlePublished           func(eventData WebhookEventArticlePublishedPayload) error           ``
+	WebhookEventArticleSubscriptionCreated func(eventData WebhookEventArticleSubscriptionCreatedPayload) error ``
+	WebhookEventArticleUnpublished         func(eventData WebhookEventArticleUnpublishedPayload) error         ``
+	WebhookEventArticleVoteCreated         func(eventData WebhookEventArticleVoteCreatedPayload) error         ``
+	WebhookEventArticleVoteChanged         func(eventData WebhookEventArticleVoteChangedPayload) error         ``
+	WebhookEventArticleVoteRemoved         func(eventData WebhookEventArticleVoteRemovedPayload) error         ``
+	WebhookEventArticleCommentCreated      func(eventData WebhookEventArticleCommentCreatedPayload) error      ``
+	WebhookEventArticleCommentChanged      func(eventData WebhookEventArticleCommentChangedPayload) error      ``
+	WebhookEventArticleCommentPublished    func(eventData WebhookEventArticleCommentPublishedPayload) error    ``
+	WebhookEventArticleCommentUnpublished  func(eventData WebhookEventArticleCommentUnpublishedPayload) error  ``
+
+	WebhookEventOrganizationCreated            func(eventData WebhookEventOrganizationCreatedPayload) error            ``
+	WebhookEventOrganizationCustomFieldChanged func(eventData WebhookEventOrganizationCustomFieldChangedPayload) error ``
+	WebhookEventOrganizationDeleted            func(eventData WebhookEventOrganizationDeletedPayload) error            ``
+	WebhookEventOrganizationExternalIDChanged  func(eventData WebhookEventOrganizationExternalIDChangedPayload) error  ``
+	WebhookEventOrganizationNameChanged        func(eventData WebhookEventOrganizationNameChangedPayload) error        ``
+	WebhookEventOrganizationTagsChanged        func(eventData WebhookEventOrganizationTagsChangedPayload) error        ``
+
+	WebhookEventUserCreated                       func(eventData WebhookEventUserCreatedPayload) error                       `zenevent:"zen:event-type:user.created"`
+	WebhookEventUserCustomFieldChanged            func(eventData WebhookEventUserCustomFieldChangedPayload) error            `zenevent:"zen:event-type:user.custom_field_changed"`
+	WebhookEventUserCustomRoleChanged             func(eventData WebhookEventUserCustomRoleChangedPayload) error             ``
+	WebhookEventUserDefaultGroupChanged           func(eventData WebhookEventUserDefaultGroupChangedPayload) error           ``
+	WebhookEventUserExternalIDChanged             func(eventData WebhookEventUserExternalIDChangedPayload) error             ``
+	WebhookEventUserGroupMembershipCreated        func(eventData WebhookEventUserGroupMembershipCreatedPayload) error        ``
+	WebhookEventUserGroupMembershipDeleted        func(eventData WebhookEventUserGroupMembershipDeletedPayload) error        ``
+	WebhookEventUserIdentityChanged               func(eventData WebhookEventUserIdentityChangedPayload) error               ``
+	WebhookEventUserIdentityCreated               func(eventData WebhookEventUserIdentityCreatedPayload) error               ``
+	WebhookEventUserIdentityDeleted               func(eventData WebhookEventUserIdentityDeletedPayload) error               ``
+	WebhookEventUserActiveChanged                 func(eventData WebhookEventUserActiveChangedPayload) error                 ``
+	WebhookEventUserLastLoginChanged              func(eventData WebhookEventUserLastLoginChangedPayload) error              ``
+	WebhookEventUserMerged                        func(eventData WebhookEventUserMergedPayload) error                        ``
+	WebhookEventUserNameChanged                   func(eventData WebhookEventUserNameChangedPayload) error                   ``
+	WebhookEventUserNotesChanged                  func(eventData WebhookEventUserNotesChangedPayload) error                  ``
+	WebhookEventUserOnlyPrivateCommentsChanged    func(eventData WebhookEventUserOnlyPrivateCommentsChangedPayload) error    ``
+	WebhookEventUserOrganizationMembershipCreated func(eventData WebhookEventUserOrganizationMembershipCreatedPayload) error ``
+	WebhookEventUserOrganizationMembershipDeleted func(eventData WebhookEventUserOrganizationMembershipDeletedPayload) error ``
+	WebhookEventUserPasswordChanged               func(eventData WebhookEventUserPasswordChangedPayload) error               ``
+	WebhookEventUserPhotoChanged                  func(eventData WebhookEventUserPhotoChangedPayload) error                  ``
+	WebhookEventUserRoleChanged                   func(eventData WebhookEventUserRoleChangedPayload) error                   ``
+	WebhookEventUserDeleted                       func(eventData WebhookEventUserDeletedPayload) error                       ``
+	WebhookEventUserSuspendedChanged              func(eventData WebhookEventUserSuspendedChangedPayload) error              ``
+	WebhookEventUserTagsChanged                   func(eventData WebhookEventUserTagsChangedPayload) error                   ``
+	WebhookEventUserTimeZoneChanged               func(eventData WebhookEventUserTimeZoneChangedPayload) error               ``
+
+	WebhookEventCommunityPostCreated             func(eventData WebhookEventCommunityPostCreatedPayload) error             ``
+	WebhookEventCommunityPostChanged             func(eventData WebhookEventCommunityPostChangedPayload) error             ``
+	WebhookEventCommunityPostPublished           func(eventData WebhookEventCommunityPostPublishedPayload) error           ``
+	WebhookEventCommunityPostUnpublished         func(eventData WebhookEventCommunityPostUnpublishedPayload) error         ``
+	WebhookEventCommunityPostSubscriptionCreated func(eventData WebhookEventCommunityPostSubscriptionCreatedPayload) error ``
+	WebhookEventCommunityPostVoteCreated         func(eventData WebhookEventCommunityPostVoteCreatedPayload) error         ``
+	WebhookEventCommunityPostVoteChanged         func(eventData WebhookEventCommunityPostVoteChangedPayload) error         ``
+	WebhookEventCommunityPostVoteRemoved         func(eventData WebhookEventCommunityPostVoteRemovedPayload) error         ``
+	WebhookEventCommunityPostCommentCreated      func(eventData WebhookEventCommunityPostCommentCreatedPayload) error      ``
+	WebhookEventCommunityPostCommentChanged      func(eventData WebhookEventCommunityPostCommentChangedPayload) error      ``
+	WebhookEventCommunityPostCommentPublished    func(eventData WebhookEventCommunityPostCommentPublishedPayload) error    ``
+	WebhookEventCommunityPostCommentUnpublished  func(eventData WebhookEventCommunityPostCommentUnpublishedPayload) error  ``
+	WebhookEventCommunityPostCommentVoteCreated  func(eventData WebhookEventCommunityPostCommentVoteCreatedPayload) error  ``
+	WebhookEventCommunityPostCommentVoteChanged  func(eventData WebhookEventCommunityPostCommentVoteChangedPayload) error  ``
+
+	WebhookEventAgentStateChanged        func(eventData WebhookEventAgentStateChangedPayload) error        ``
+	WebhookEventAgentWorkItemAdded       func(eventData WebhookEventAgentWorkItemAddedPayload) error       ``
+	WebhookEventAgentWorkItemRemoved     func(eventData WebhookEventAgentWorkItemRemovedPayload) error     ``
+	WebhookEventAgentMaxCapacityChanged  func(eventData WebhookEventAgentMaxCapacityChangedPayload) error  ``
+	WebhookEventAgentUnifiedStateChanged func(eventData WebhookEventAgentUnifiedStateChangedPayload) error ``
+	WebhookEventAgentChannelCreated      func(eventData WebhookEventAgentChannelCreatedPayload) error      ``
+	WebhookEventAgentChannelDeleted      func(eventData WebhookEventAgentChannelDeletedPayload) error      ``
+
+	WebhookEventOmnichannelRoutingConfigFeatureChanged func(eventData WebhookEventOmnichannelRoutingConfigFeatureChangedPayload) error ``
 }
 
-func (s WebhookService) WebhookEvent(handlers WebhookEventHandlers, secret string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// TODO: auth and unmarshal - hand wavy part
+// Base webhookevent for Event Based webhooks
+type WebhookEvent struct {
+	Type                WebhookEventType `json:"type"`
+	AccountID           AccountID        `json:"account_id"`
+	ID                  WebhookEventID   `json:"id"`
+	Time                time.Time        `json:"time"`
+	ZendeskEventVersion string           `json:"zendesk_event_version"`
+	Subject             string           `json:"subject"`
+	Event               any              `json:"event"`
+	Detail              any              `json:"detail"`
+}
 
-		if subject && handlers.EventTypeArticleAuthorChanged != nil {
-			handlers.UserEvent(Event[User]{})
+func (s *WebhookService) HandleWebhookEvent(webhookSigningSecret string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		webhookBody, err := readWebhookBody(r)
+		if err != nil {
+			respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
 			return
 		}
-	})
-}
 
-func (s WebhookService) WebhookTrigger(handler func(b []byte), secret string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		baseTarget := WebhookEvent{}
+		if err := json.Unmarshal(webhookBody, &baseTarget); err != nil {
+			respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
-	})
-}
+			return
+		}
 
-func (s WebhookService) HandleWebhook(
-	processor func(requestBody []byte) error,
-	webhookSigningSecret string,
-) http.Handler {
-	return http.HandlerFunc(
-		func(
-			w http.ResponseWriter,
-			r *http.Request,
-		) {
-			// Verifying webhook requests is optional
-			if webhookSigningSecret != "" {
-				s.verifyZendeskWebhookSignature(w, r, webhookSigningSecret)
-			}
+		if baseTarget.Type == "" {
+			respondToWebhookRequest(w, http.StatusBadRequest, "Bad Request")
 
-			// TODO: Include authentication methods
-			// https://developer.zendesk.com/documentation/webhooks/webhook-security-and-authentication/#webhook-authentication
+			return
+		}
 
-			body, err := readWebhookBody(r)
-			if err != nil {
-				respondToWebhookRequest(
-					w,
-					http.StatusInternalServerError,
-					"Could not read Webhook Request body",
-				)
+		if webhookSigningSecret != "" {
+			if !s.verifyZendeskWebhookSignatureIsValid(r, webhookBody, webhookSigningSecret) {
+				respondToWebhookRequest(w, http.StatusBadRequest, "Bad Request")
 
 				return
 			}
+		}
 
-			if err := processor(body); err != nil {
-				respondToWebhookRequest(
-					w,
-					http.StatusInternalServerError,
-					"Error occurred while processing webhook request",
-				)
+		switch baseTarget.Type {
+		case WebhookEventArticlePublished:
+			if s.eventHandlers.WebhookEventArticlePublished != nil {
+				target := WebhookEventArticlePublishedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
-				return
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventArticlePublished(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
 			}
+		case WebhookEventArticleSubscriptionCreated:
+			if s.eventHandlers.WebhookEventArticleSubscriptionCreated != nil {
+				target := WebhookEventArticleSubscriptionCreatedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
 
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventArticleSubscriptionCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventArticleUnpublished:
+			if s.eventHandlers.WebhookEventArticleUnpublished != nil {
+				target := WebhookEventArticleUnpublishedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventArticleUnpublished(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventArticleVoteCreated:
+			if s.eventHandlers.WebhookEventArticleVoteCreated != nil {
+				target := WebhookEventArticleVoteCreatedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventArticleVoteCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventArticleVoteChanged:
+			if s.eventHandlers.WebhookEventArticleVoteChanged != nil {
+				target := WebhookEventArticleVoteChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventArticleVoteChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventArticleCommentCreated:
+			if s.eventHandlers.WebhookEventArticleCommentCreated != nil {
+				target := WebhookEventArticleCommentCreatedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventArticleCommentCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventArticleCommentChanged:
+			if s.eventHandlers.WebhookEventArticleCommentChanged != nil {
+				target := WebhookEventArticleCommentChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventArticleCommentChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventArticleCommentPublished:
+			if s.eventHandlers.WebhookEventArticleCommentPublished != nil {
+				target := WebhookEventArticleCommentPublishedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventArticleCommentPublished(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventArticleCommentUnpublished:
+			if s.eventHandlers.WebhookEventArticleCommentUnpublished != nil {
+				target := WebhookEventArticleCommentUnpublishedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventArticleCommentUnpublished(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventOrganizationCreated:
+			if s.eventHandlers.WebhookEventOrganizationCreated != nil {
+				target := WebhookEventOrganizationCreatedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventOrganizationCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventOrganizationCustomFieldChanged:
+			if s.eventHandlers.WebhookEventOrganizationCustomFieldChanged != nil {
+				target := WebhookEventOrganizationCustomFieldChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventOrganizationCustomFieldChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventOrganizationDeleted:
+			if s.eventHandlers.WebhookEventOrganizationDeleted != nil {
+				target := WebhookEventOrganizationDeletedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventOrganizationDeleted(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserLastLoginChanged:
+			if s.eventHandlers.WebhookEventUserLastLoginChanged != nil {
+				target := WebhookEventUserLastLoginChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserLastLoginChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserMerged:
+			if s.eventHandlers.WebhookEventUserMerged != nil {
+				target := WebhookEventUserMergedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserMerged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserNameChanged:
+			if s.eventHandlers.WebhookEventUserNameChanged != nil {
+				target := WebhookEventUserNameChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserNameChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserNotesChanged:
+			if s.eventHandlers.WebhookEventUserNotesChanged != nil {
+				target := WebhookEventUserNotesChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserNotesChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserOnlyPrivateCommentsChanged:
+			if s.eventHandlers.WebhookEventUserOnlyPrivateCommentsChanged != nil {
+				target := WebhookEventUserOnlyPrivateCommentsChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserOnlyPrivateCommentsChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserOrganizationMembershipCreated:
+			if s.eventHandlers.WebhookEventUserOrganizationMembershipCreated != nil {
+				target := WebhookEventUserOrganizationMembershipCreatedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserOrganizationMembershipCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserOrganizationMembershipDeleted:
+			if s.eventHandlers.WebhookEventUserOrganizationMembershipDeleted != nil {
+				target := WebhookEventUserOrganizationMembershipDeletedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserOrganizationMembershipDeleted(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserPasswordChanged:
+			if s.eventHandlers.WebhookEventUserPasswordChanged != nil {
+				target := WebhookEventUserPasswordChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserPasswordChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserPhotoChanged:
+			if s.eventHandlers.WebhookEventUserPhotoChanged != nil {
+				target := WebhookEventUserPhotoChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserPhotoChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserRoleChanged:
+			if s.eventHandlers.WebhookEventUserRoleChanged != nil {
+				target := WebhookEventUserRoleChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserRoleChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserDeleted:
+			if s.eventHandlers.WebhookEventUserDeleted != nil {
+				target := WebhookEventUserDeletedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserDeleted(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserActiveChanged:
+			if s.eventHandlers.WebhookEventUserActiveChanged != nil {
+				target := WebhookEventUserActiveChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserActiveChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserSuspendedChanged:
+			if s.eventHandlers.WebhookEventUserSuspendedChanged != nil {
+				target := WebhookEventUserSuspendedChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserSuspendedChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserTagsChanged:
+			if s.eventHandlers.WebhookEventUserTagsChanged != nil {
+				target := WebhookEventUserTagsChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserTagsChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventUserTimeZoneChanged:
+			if s.eventHandlers.WebhookEventUserTimeZoneChanged != nil {
+				target := WebhookEventUserTimeZoneChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventUserTimeZoneChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostCreated:
+			if s.eventHandlers.WebhookEventCommunityPostCreated != nil {
+				target := WebhookEventCommunityPostCreatedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostChanged:
+			if s.eventHandlers.WebhookEventCommunityPostChanged != nil {
+				target := WebhookEventCommunityPostChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostPublished:
+			if s.eventHandlers.WebhookEventCommunityPostPublished != nil {
+				target := WebhookEventCommunityPostPublishedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostPublished(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostUnpublished:
+			if s.eventHandlers.WebhookEventCommunityPostUnpublished != nil {
+				target := WebhookEventCommunityPostUnpublishedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostUnpublished(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostSubscriptionCreated:
+			if s.eventHandlers.WebhookEventCommunityPostSubscriptionCreated != nil {
+				target := WebhookEventCommunityPostSubscriptionCreatedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostSubscriptionCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostVoteCreated:
+			if s.eventHandlers.WebhookEventCommunityPostVoteCreated != nil {
+				target := WebhookEventCommunityPostVoteCreatedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostVoteCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostVoteChanged:
+			if s.eventHandlers.WebhookEventCommunityPostVoteChanged != nil {
+				target := WebhookEventCommunityPostVoteChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostVoteChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostVoteRemoved:
+			if s.eventHandlers.WebhookEventCommunityPostVoteRemoved != nil {
+				target := WebhookEventCommunityPostVoteRemovedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostVoteRemoved(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostCommentCreated:
+			if s.eventHandlers.WebhookEventCommunityPostCommentCreated != nil {
+				target := WebhookEventCommunityPostCommentCreatedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostCommentCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostCommentChanged:
+			if s.eventHandlers.WebhookEventCommunityPostCommentChanged != nil {
+				target := WebhookEventCommunityPostCommentChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostCommentChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostCommentPublished:
+			if s.eventHandlers.WebhookEventCommunityPostCommentPublished != nil {
+				target := WebhookEventCommunityPostCommentPublishedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostCommentPublished(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostCommentUnpublished:
+			if s.eventHandlers.WebhookEventCommunityPostCommentUnpublished != nil {
+				target := WebhookEventCommunityPostCommentUnpublishedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostCommentUnpublished(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostCommentVoteCreated:
+			if s.eventHandlers.WebhookEventCommunityPostCommentVoteCreated != nil {
+				target := WebhookEventCommunityPostCommentVoteCreatedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostCommentVoteCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventCommunityPostCommentVoteChanged:
+			if s.eventHandlers.WebhookEventCommunityPostCommentVoteChanged != nil {
+				target := WebhookEventCommunityPostCommentVoteChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventCommunityPostCommentVoteChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventAgentStateChanged:
+			if s.eventHandlers.WebhookEventAgentStateChanged != nil {
+				target := WebhookEventAgentStateChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventAgentStateChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventAgentWorkItemAdded:
+			if s.eventHandlers.WebhookEventAgentWorkItemAdded != nil {
+				target := WebhookEventAgentWorkItemAddedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventAgentWorkItemAdded(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventAgentWorkItemRemoved:
+			if s.eventHandlers.WebhookEventAgentWorkItemRemoved != nil {
+				target := WebhookEventAgentWorkItemRemovedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventAgentWorkItemRemoved(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventAgentMaxCapacityChanged:
+			if s.eventHandlers.WebhookEventAgentMaxCapacityChanged != nil {
+				target := WebhookEventAgentMaxCapacityChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventAgentMaxCapacityChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventAgentUnifiedStateChanged:
+			if s.eventHandlers.WebhookEventAgentUnifiedStateChanged != nil {
+				target := WebhookEventAgentUnifiedStateChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventAgentUnifiedStateChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventAgentChannelCreated:
+			if s.eventHandlers.WebhookEventAgentChannelCreated != nil {
+				target := WebhookEventAgentChannelCreatedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventAgentChannelCreated(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventAgentChannelDeleted:
+			if s.eventHandlers.WebhookEventAgentChannelDeleted != nil {
+				target := WebhookEventAgentChannelDeletedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventAgentChannelDeleted(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		case WebhookEventOmnichannelRoutingConfigFeatureChanged:
+			if s.eventHandlers.WebhookEventOmnichannelRoutingConfigFeatureChanged != nil {
+				target := WebhookEventOmnichannelRoutingConfigFeatureChangedPayload{}
+				if err := json.Unmarshal(webhookBody, &target); err != nil {
+					respondToWebhookRequest(w, http.StatusBadRequest, err.Error())
+
+					return
+				}
+
+				if err := s.eventHandlers.WebhookEventOmnichannelRoutingConfigFeatureChanged(target); err != nil {
+					respondToWebhookRequest(
+						w,
+						http.StatusInternalServerError,
+						err.Error(),
+					)
+
+					return
+				}
+			}
+		default:
 			respondToWebhookRequest(
 				w,
-				http.StatusOK,
-				"Successfully handled Webhook Request",
+				http.StatusBadRequest,
+				"Unknown webhook event type",
 			)
-		},
+
+			return
+		}
+
+		respondToWebhookRequest(w, http.StatusOK, "Success")
+	},
 	)
 }
 
-// https://developer.zendesk.com/documentation/webhooks/verifying/
-func (s WebhookService) verifyZendeskWebhookSignature(w http.ResponseWriter, r *http.Request, webhookSigningSecret string) {
-	bodyBytes, err := io.ReadAll(r.Body)
-	if err != nil {
-		respondToWebhookRequest(
-			w,
-			http.StatusBadRequest,
-			"Bad Request",
-		)
-	}
-	r.Body.Close()
-	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+func (s *WebhookService) WebhookTriggerHandler(handler func(b []byte), secret string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
+	})
+}
+
+type WebhookEventOrganization[EventData WebhookOrganizationEventData] struct {
+	Type                WebhookEventType          `json:"type"`
+	AccountID           AccountID                 `json:"account_id"`
+	ID                  WebhookEventID            `json:"id"`
+	Time                time.Time                 `json:"time"`
+	ZendeskEventVersion string                    `json:"zendesk_event_version"`
+	Subject             string                    `json:"subject"`
+	Event               EventData                 `json:"event"`
+	Detail              WebhookEventArticleDetail `json:"detail"`
+}
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/webhook-event-types/
+type WebhookEventArticle[EventData WebhookArticleEventData] struct {
+	Type                WebhookEventType          `json:"type"`
+	AccountID           AccountID                 `json:"account_id"`
+	ID                  WebhookEventID            `json:"id"`
+	Time                time.Time                 `json:"time"`
+	ZendeskEventVersion string                    `json:"zendesk_event_version"`
+	Subject             string                    `json:"subject"`
+	Event               EventData                 `json:"event"`
+	Detail              WebhookEventArticleDetail `json:"detail"`
+}
+
+type WebhookEventCommunityPost[EventData WebhookCommunityPostEventData] struct {
+	Type                WebhookEventType          `json:"type"`
+	AccountID           AccountID                 `json:"account_id"`
+	ID                  WebhookEventID            `json:"id"`
+	Time                time.Time                 `json:"time"`
+	ZendeskEventVersion string                    `json:"zendesk_event_version"`
+	Subject             string                    `json:"subject"`
+	Event               EventData                 `json:"event"`
+	Detail              WebhookEventArticleDetail `json:"detail"`
+}
+
+type WebhookEventAgentState[EventData WebhookAgentStateEventData] struct {
+	Type                WebhookEventType          `json:"type"`
+	AccountID           AccountID                 `json:"account_id"`
+	ID                  WebhookEventID            `json:"id"`
+	Time                time.Time                 `json:"time"`
+	ZendeskEventVersion string                    `json:"zendesk_event_version"`
+	Subject             string                    `json:"subject"`
+	Event               EventData                 `json:"event"`
+	Detail              WebhookEventArticleDetail `json:"detail"`
+}
+
+type WebhookEventOmnichannelRoutingConfig[EventData WebhookOmnichannelRoutingConfigData] struct {
+	Type                WebhookEventType          `json:"type"`
+	AccountID           AccountID                 `json:"account_id"`
+	ID                  WebhookEventID            `json:"id"`
+	Time                time.Time                 `json:"time"`
+	ZendeskEventVersion string                    `json:"zendesk_event_version"`
+	Subject             string                    `json:"subject"`
+	Event               EventData                 `json:"event"`
+	Detail              WebhookEventArticleDetail `json:"detail"`
+}
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/
+type WebhookEventArticleDetail struct {
+	BrandID BrandID   `json:"brand_id"`
+	ID      ArticleID `json:"id"`
+}
+
+type WebhookArticleEventData interface {
+	EventTypeArticleAuthorChangedEvent | any
+}
+
+type WebhookOrganizationEventData interface {
+	any
+}
+
+type WebhookAgentStateEventData interface {
+	any
+}
+
+type WebhookOmnichannelRoutingConfigData interface {
+	any
+}
+
+type WebhookCommunityPostEventData interface {
+	any
+}
+
+type WebhookEventArticleAuthorChangedPayload WebhookEventArticle[EventTypeArticleAuthorChangedEvent]
+
+type EventTypeArticleAuthorChangedEvent struct {
+}
+
+type WebhookEventUser[EventData WebhookUserEventData] struct {
+	Type                WebhookEventType       `json:"type"`
+	AccountID           AccountID              `json:"account_id"`
+	ID                  WebhookEventID         `json:"id"`
+	Time                time.Time              `json:"time"`
+	ZendeskEventVersion string                 `json:"zendesk_event_version"`
+	Subject             string                 `json:"subject"`
+	Event               EventData              `json:"event"`
+	Detail              WebhookEventUserDetail `json:"detail"`
+}
+
+type WebhookEventUserDetail struct {
+	CreatedAt      time.Time    `json:"created_at"`
+	Email          string       `json:"email"`
+	ExternalID     string       `json:"external_id"`
+	DefaultGroupID string       `json:"default_group_id"`
+	ID             string       `json:"id"`
+	OrganizationID string       `json:"organization_id"`
+	Role           CustomRoleID `json:"role"`
+	UpdatedAt      time.Time    `json:"updated_at"`
+}
+
+type WebhookUserEventData interface {
+	WebhookEventUserAliasChangedPayload |
+		WebhookEventUserActiveStatusChangedPayload |
+		WebhookEventUserDetailsChangedPayload |
+		any
+}
+
+type WebhookEventUserActiveStatusChangedPayload struct {
+	Current  bool `json:"current"`
+	Previous bool `json:"previous"`
+}
+
+type WebhookEventUserDetailsChangedPayload struct {
+	Current  string `json:"current"`
+	Previous string `json:"previous"`
+}
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/community-events/#detail-object-properties
+type WebhookEventDetailCommunityPost struct {
+	BrandID BrandID `json:"brand_id"`
+	PostID  PostID  `json:"post_id"`
+	TopicID TopicID `json:"topic_id"`
+}
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/organization-events/#detail-object-properties
+type WebhookEventDetailOrganization struct {
+	CreatedAt      time.Time `json:"created_at"`
+	ExternalID     *string   `json:"external_id"`
+	GroupID        *string   `json:"group_id"`
+	ID             string    `json:"id"`
+	Name           string    `json:"name"`
+	SharedComments bool      `json:"shared_comments"`
+	SharedTickets  bool      `json:"shared_tickets"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// https://developer.zendesk.com/documentation/webhooks/verifying/
+func (s WebhookService) verifyZendeskWebhookSignatureIsValid(
+	r *http.Request,
+	bodyBytes []byte,
+	webhookSigningSecret string,
+) bool {
 	expectedZendeskSignature := r.Header.Get(WebhookHeaderSignature)
 	zendeskSignatureTimestamp := r.Header.Get(WebhookHeaderSignatureTimestamp)
 	if expectedZendeskSignature == "" || zendeskSignatureTimestamp == "" {
-		respondToWebhookRequest(
-			w,
-			http.StatusBadRequest,
-			"Bad Request",
-		)
-
-		return
+		return false
 	}
 
 	actualZendeskSignature := buildZendeskSignature(zendeskSignatureTimestamp, bodyBytes, webhookSigningSecret)
-	if expectedZendeskSignature != actualZendeskSignature {
-		respondToWebhookRequest(
-			w,
-			http.StatusBadRequest,
-			"Bad Request",
-		)
-
-		return
-	}
+	return expectedZendeskSignature != actualZendeskSignature
 }
 
 func buildZendeskSignature(
@@ -172,127 +1380,72 @@ func readWebhookBody(r *http.Request) ([]byte, error) {
 	return bodyBytes, nil
 }
 
-// https://developer.zendesk.com/api-reference/webhooks/event-types/webhook-event-types/
-type WebhookEventArticle[Event any] struct {
-	Type                WebhookEventType          `json:"type"`
-	AccountID           AccountID                 `json:"account_id"`
-	ID                  WebhookEventID            `json:"id"`
-	Time                time.Time                 `json:"time"`
-	ZendeskEventVersion string                    `json:"zendesk_event_version"`
-	Subject             string                    `json:"subject"`
-	Event               Event                     `json:"event"`
-	Detail              WebhookEventArticleDetail `json:"detail"`
-}
+type WebhookEventUserAliasChangedPayload WebhookEventUser[any]
+type WebhookEventUserCreatedPayload WebhookEventUser[any]
+type WebhookEventUserCustomFieldChangedPayload WebhookEventUser[any]
+type WebhookEventUserCustomRoleChangedPayload WebhookEventUser[any]
+type WebhookEventUserDefaultGroupChangedPayload WebhookEventUser[any]
+type WebhookEventUserExternalIDChangedPayload WebhookEventUser[any]
+type WebhookEventUserGroupMembershipCreatedPayload WebhookEventUser[any]
+type WebhookEventUserGroupMembershipDeletedPayload WebhookEventUser[any]
+type WebhookEventUserIdentityChangedPayload WebhookEventUser[any]
+type WebhookEventUserIdentityCreatedPayload WebhookEventUser[any]
+type WebhookEventUserIdentityDeletedPayload WebhookEventUser[any]
+type WebhookEventUserActiveChangedPayload WebhookEventUser[any]
+type WebhookEventUserLastLoginChangedPayload WebhookEventUser[any]
+type WebhookEventUserMergedPayload WebhookEventUser[any]
+type WebhookEventUserNameChangedPayload WebhookEventUser[any]
+type WebhookEventUserNotesChangedPayload WebhookEventUser[any]
+type WebhookEventUserOnlyPrivateCommentsChangedPayload WebhookEventUser[any]
+type WebhookEventUserOrganizationMembershipCreatedPayload WebhookEventUser[any]
+type WebhookEventUserOrganizationMembershipDeletedPayload WebhookEventUser[any]
+type WebhookEventUserPasswordChangedPayload WebhookEventUser[any]
+type WebhookEventUserPhotoChangedPayload WebhookEventUser[any]
+type WebhookEventUserRoleChangedPayload WebhookEventUser[any]
+type WebhookEventUserDeletedPayload WebhookEventUser[any]
+type WebhookEventUserSuspendedChangedPayload WebhookEventUser[any]
+type WebhookEventUserTagsChangedPayload WebhookEventUser[any]
+type WebhookEventUserTimeZoneChangedPayload WebhookEventUser[any]
 
-// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/
-type WebhookEventArticleDetail struct {
-	BrandID BrandID   `json:"brand_id"`
-	ID      ArticleID `json:"id"`
-}
+type WebhookEventOrganizationCreatedPayload WebhookEventOrganization[any]
+type WebhookEventOrganizationCustomFieldChangedPayload WebhookEventOrganization[any]
+type WebhookEventOrganizationDeletedPayload WebhookEventOrganization[any]
+type WebhookEventOrganizationExternalIDChangedPayload WebhookEventOrganization[any]
+type WebhookEventOrganizationNameChangedPayload WebhookEventOrganization[any]
+type WebhookEventOrganizationTagsChangedPayload WebhookEventOrganization[any]
 
-type WebhookEventArticleAuthorChanged WebhookEventArticle[EventTypeArticleAuthorChangedEvent]
-type EventTypeArticleAuthorChangedEvent struct {
-}
+type WebhookEventArticlePublishedPayload WebhookEventArticle[any]
+type WebhookEventArticleSubscriptionCreatedPayload WebhookEventArticle[any]
+type WebhookEventArticleUnpublishedPayload WebhookEventArticle[any]
+type WebhookEventArticleVoteCreatedPayload WebhookEventArticle[any]
+type WebhookEventArticleVoteChangedPayload WebhookEventArticle[any]
+type WebhookEventArticleVoteRemovedPayload WebhookEventArticle[any]
+type WebhookEventArticleCommentCreatedPayload WebhookEventArticle[any]
+type WebhookEventArticleCommentChangedPayload WebhookEventArticle[any]
+type WebhookEventArticleCommentPublishedPayload WebhookEventArticle[any]
+type WebhookEventArticleCommentUnpublishedPayload WebhookEventArticle[any]
 
-type WebhookEventUser[Event any] struct {
-	Type                WebhookEventType       `json:"type"`
-	AccountID           AccountID              `json:"account_id"`
-	ID                  WebhookEventID         `json:"id"`
-	Time                time.Time              `json:"time"`
-	ZendeskEventVersion string                 `json:"zendesk_event_version"`
-	Subject             string                 `json:"subject"`
-	Event               Event                  `json:"event"`
-	Detail              WebhookEventUserDetail `json:"detail"`
-}
+type WebhookEventCommunityPostCreatedPayload WebhookEventCommunityPost[any]
+type WebhookEventCommunityPostChangedPayload WebhookEventCommunityPost[any]
+type WebhookEventCommunityPostPublishedPayload WebhookEventCommunityPost[any]
+type WebhookEventCommunityPostUnpublishedPayload WebhookEventCommunityPost[any]
+type WebhookEventCommunityPostSubscriptionCreatedPayload WebhookEventCommunityPost[any]
+type WebhookEventCommunityPostVoteCreatedPayload WebhookEventCommunityPost[any]
+type WebhookEventCommunityPostVoteChangedPayload WebhookEventCommunityPost[any]
+type WebhookEventCommunityPostVoteRemovedPayload WebhookEventCommunityPost[any]
+type WebhookEventCommunityPostCommentCreatedPayload WebhookEventCommunityPost[any]
+type WebhookEventCommunityPostCommentChangedPayload WebhookEventCommunityPost[any]
+type WebhookEventCommunityPostCommentPublishedPayload WebhookEventCommunityPost[any]
+type WebhookEventCommunityPostCommentUnpublishedPayload WebhookEventCommunityPost[any]
+type WebhookEventCommunityPostCommentVoteCreatedPayload WebhookEventCommunityPost[any]
+type WebhookEventCommunityPostCommentVoteChangedPayload WebhookEventCommunityPost[any]
 
-type WebhookEventUserDetail struct {
-	CreatedAt      time.Time    `json:"created_at"`
-	Email          string       `json:"email"`
-	ExternalID     string       `json:"external_id"`
-	DefaultGroupID string       `json:"default_group_id"`
-	ID             string       `json:"id"`
-	OrganizationID string       `json:"organization_id"`
-	Role           CustomRoleID `json:"role"`
-	UpdatedAt      time.Time    `json:"updated_at"`
-}
+type WebhookEventAgentStateChangedPayload WebhookEventAgentState[any]
+type WebhookEventAgentWorkItemAddedPayload WebhookEventAgentState[any]
+type WebhookEventAgentWorkItemRemovedPayload WebhookEventAgentState[any]
+type WebhookEventAgentMaxCapacityChangedPayload WebhookEventAgentState[any]
+type WebhookEventAgentUnifiedStateChangedPayload WebhookEventAgentState[any]
+type WebhookEventAgentChannelCreatedPayload WebhookEventAgentState[any]
+type WebhookEventAgentChannelDeletedPayload WebhookEventAgentState[any]
 
-// type WebhookEventUser[Event WebhookUserEventData] struct {
-// 	WebhookEvent
-// 	Event  Event                  `json:"event"`
-// 	Detail WebhookEventDetailUser `json:"detail"`
-// }
-
-type WebhookUserEventData interface {
-	WebhookEventUserActiveStatusChanged | WebhookEventUserDetailsChanged
-}
-
-// // https://developer.zendesk.com/api-reference/webhooks/event-types/user-events/#detail-object-properties
-
-type WebhookEventUserActiveStatusChanged struct {
-	Current  bool `json:"current"`
-	Previous bool `json:"previous"`
-}
-
-type WebhookEventUserDetailsChanged struct {
-	Current  string `json:"current"`
-	Previous string `json:"previous"`
-}
-
-// https://developer.zendesk.com/api-reference/webhooks/event-types/community-events/
-type WebhookEventCommunityPost struct {
-	Detail WebhookEventDetailCommunityPost `json:"detail"`
-	Event  any                             `json:"event"`
-	WebhookEvent
-}
-
-// https://developer.zendesk.com/api-reference/webhooks/event-types/community-events/#detail-object-properties
-type WebhookEventDetailCommunityPost struct {
-	BrandID BrandID `json:"brand_id"`
-	PostID  PostID  `json:"post_id"`
-	TopicID TopicID `json:"topic_id"`
-}
-
-// https://developer.zendesk.com/api-reference/webhooks/event-types/organization-events/
-type WebhookEventOrganization struct {
-	Detail WebhookEventDetailOrganization `json:"detail"`
-	Event  any                            `json:"event"`
-	WebhookEvent
-}
-
-// https://developer.zendesk.com/api-reference/webhooks/event-types/organization-events/#detail-object-properties
-type WebhookEventDetailOrganization struct {
-	CreatedAt      time.Time `json:"created_at"`
-	ExternalID     *string   `json:"external_id"`
-	GroupID        *string   `json:"group_id"`
-	ID             string    `json:"id"`
-	Name           string    `json:"name"`
-	SharedComments bool      `json:"shared_comments"`
-	SharedTickets  bool      `json:"shared_tickets"`
-	UpdatedAt      time.Time `json:"updated_at"`
-}
-
-// https://developer.zendesk.com/api-reference/webhooks/event-types/omnichannel-routing-configuration-events/
-type WebhookEventOmnichannelRoutingConfig struct {
-	Detail WebhookEventDetailOmnichannelRoutingConfig `json:"detail"`
-	Event  any                                        `json:"event"`
-	WebhookEvent
-}
-
-// https://developer.zendesk.com/api-reference/webhooks/event-types/omnichannel-routing-configuration-events/#detail-object-properties
-type WebhookEventDetailOmnichannelRoutingConfig struct {
-	AccountID AccountID `json:"account_id"`
-}
-
-// https://developer.zendesk.com/api-reference/webhooks/event-types/agent-availability-events/
-type WebhookEventAgentAvailability struct {
-	Detail WebhookEventDetailAgentAvailability `json:"detail"`
-	Event  any                                 `json:"event"`
-	WebhookEvent
-}
-
-// https://developer.zendesk.com/api-reference/webhooks/event-types/agent-availability-events/#detail-object-properties
-type WebhookEventDetailAgentAvailability struct {
-	AccountID AccountID `json:"account_id"`
-	AgentID   string    `json:"agent_id"`
-	Version   string    `json:"version"`
-}
+type WebhookEventOmnichannelRoutingConfigFeatureChangedPayload WebhookEventOmnichannelRoutingConfig[any]

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-
 	"time"
 )
 
@@ -89,7 +88,7 @@ const (
 	WebhookEventUserOnlyPrivateCommentsChanged    WebhookEventType = "zen:event-type:user.only_private_comments_changed"
 	WebhookEventUserOrganizationMembershipCreated WebhookEventType = "zen:event-type:user.organization_membership_created"
 	WebhookEventUserOrganizationMembershipDeleted WebhookEventType = "zen:event-type:user.organization_membership_deleted"
-	WebhookEventUserPasswordChanged               WebhookEventType = "zen:event-type:user.password_changed"
+	WebhookEventUserPasswordChanged               WebhookEventType = "zen:event-type:user.password_changed" // #nosec G101 -- This is a false positive
 	WebhookEventUserPhotoChanged                  WebhookEventType = "zen:event-type:user.photo_changed"
 	WebhookEventUserRoleChanged                   WebhookEventType = "zen:event-type:user.role_changed"
 	WebhookEventUserDeleted                       WebhookEventType = "zen:event-type:user.deleted"
@@ -187,7 +186,7 @@ type WebhookEventHandlers struct {
 	WebhookEventOmnichannelRoutingConfigFeatureChanged func(eventData WebhookEventOmnichannelRoutingConfigFeatureChangedPayload) error ``
 }
 
-// Base webhookevent for Event Based webhooks
+// Base webhookevent for Event Based webhooks.
 type WebhookEvent struct {
 	Type                WebhookEventType `json:"type"`
 	AccountID           AccountID        `json:"account_id"`
@@ -199,6 +198,7 @@ type WebhookEvent struct {
 	Detail              any              `json:"detail"`
 }
 
+//gocyclo:ignore
 func (s *WebhookService) HandleWebhookEvent(eventHandlers WebhookEventHandlers, webhookSigningSecret string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		webhookBody, err := readWebhookBody(r)
@@ -1603,8 +1603,7 @@ type WebhookCommunityPostEventData interface {
 	any
 }
 
-type EventTypeArticleAuthorChangedEvent struct {
-}
+type EventTypeArticleAuthorChangedEvent struct{}
 
 type WebhookEventUser[EventData WebhookUserEventData] struct {
 	Type                WebhookEventType       `json:"type"`
@@ -1667,11 +1666,13 @@ func (s WebhookService) verifyZendeskWebhookSignatureIsValid(
 ) bool {
 	expectedZendeskSignature := r.Header.Get(WebhookHeaderSignature)
 	zendeskSignatureTimestamp := r.Header.Get(WebhookHeaderSignatureTimestamp)
+
 	if expectedZendeskSignature == "" || zendeskSignatureTimestamp == "" {
 		return false
 	}
 
 	actualZendeskSignature := buildZendeskSignature(zendeskSignatureTimestamp, bodyBytes, webhookSigningSecret)
+
 	return expectedZendeskSignature == actualZendeskSignature
 }
 
@@ -1779,74 +1780,84 @@ type WebhookEventDataTagsChanged struct {
 	} `json:"removed"`
 }
 
-type WebhookEventUserAliasChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
-type WebhookEventUserCreatedPayload WebhookEventUser[WebhookEventDataEmpty]
-type WebhookEventUserCustomFieldChangedPayload WebhookEventUser[WebhookEventDataCustomFieldUpdate]
-type WebhookEventUserCustomRoleChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
-type WebhookEventUserDefaultGroupChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
-type WebhookEventUserDetailsChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
-type WebhookEventUserExternalIDChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
-type WebhookEventUserGroupMembershipCreatedPayload WebhookEventUser[WebhookEventDataUserGroupMembershipChanged]
-type WebhookEventUserGroupMembershipDeletedPayload WebhookEventUser[WebhookEventDataUserGroupMembershipChanged]
-type WebhookEventUserIdentityChangedPayload WebhookEventUser[WebhookEventDataUserIdentityChanged]
-type WebhookEventUserIdentityCreatedPayload WebhookEventUser[WebhookEventDataUserIdentity]
-type WebhookEventUserIdentityDeletedPayload WebhookEventUser[WebhookEventDataUserIdentity]
-type WebhookEventUserActiveChangedPayload WebhookEventUser[WebhookEventDataSimpleBoolUpdate]
-type WebhookEventUserLastLoginChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
-type WebhookEventUserMergedPayload WebhookEventUser[WebhookEventDataUserMerged]
-type WebhookEventUserNameChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
-type WebhookEventUserNotesChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
-type WebhookEventUserOnlyPrivateCommentsChangedPayload WebhookEventUser[WebhookEventDataSimpleBoolUpdate]
-type WebhookEventUserOrganizationMembershipCreatedPayload WebhookEventUser[WebhookEventDataUserOrganizationMembershipChanged]
-type WebhookEventUserOrganizationMembershipDeletedPayload WebhookEventUser[WebhookEventDataUserOrganizationMembershipChanged]
-type WebhookEventUserPasswordChangedPayload WebhookEventUser[WebhookEventDataEmpty]
-type WebhookEventUserPhotoChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
-type WebhookEventUserRoleChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
-type WebhookEventUserDeletedPayload WebhookEventUser[WebhookEventDataEmpty]
-type WebhookEventUserSuspendedChangedPayload WebhookEventUser[WebhookEventDataSimpleBoolUpdate]
-type WebhookEventUserTagsChangedPayload WebhookEventUser[WebhookEventDataTagsChanged]
-type WebhookEventUserTimeZoneChangedPayload WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+type (
+	WebhookEventUserAliasChangedPayload                  WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+	WebhookEventUserCreatedPayload                       WebhookEventUser[WebhookEventDataEmpty]
+	WebhookEventUserCustomFieldChangedPayload            WebhookEventUser[WebhookEventDataCustomFieldUpdate]
+	WebhookEventUserCustomRoleChangedPayload             WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+	WebhookEventUserDefaultGroupChangedPayload           WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+	WebhookEventUserDetailsChangedPayload                WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+	WebhookEventUserExternalIDChangedPayload             WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+	WebhookEventUserGroupMembershipCreatedPayload        WebhookEventUser[WebhookEventDataUserGroupMembershipChanged]
+	WebhookEventUserGroupMembershipDeletedPayload        WebhookEventUser[WebhookEventDataUserGroupMembershipChanged]
+	WebhookEventUserIdentityChangedPayload               WebhookEventUser[WebhookEventDataUserIdentityChanged]
+	WebhookEventUserIdentityCreatedPayload               WebhookEventUser[WebhookEventDataUserIdentity]
+	WebhookEventUserIdentityDeletedPayload               WebhookEventUser[WebhookEventDataUserIdentity]
+	WebhookEventUserActiveChangedPayload                 WebhookEventUser[WebhookEventDataSimpleBoolUpdate]
+	WebhookEventUserLastLoginChangedPayload              WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+	WebhookEventUserMergedPayload                        WebhookEventUser[WebhookEventDataUserMerged]
+	WebhookEventUserNameChangedPayload                   WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+	WebhookEventUserNotesChangedPayload                  WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+	WebhookEventUserOnlyPrivateCommentsChangedPayload    WebhookEventUser[WebhookEventDataSimpleBoolUpdate]
+	WebhookEventUserOrganizationMembershipCreatedPayload WebhookEventUser[WebhookEventDataUserOrganizationMembershipChanged]
+	WebhookEventUserOrganizationMembershipDeletedPayload WebhookEventUser[WebhookEventDataUserOrganizationMembershipChanged]
+	WebhookEventUserPasswordChangedPayload               WebhookEventUser[WebhookEventDataEmpty]
+	WebhookEventUserPhotoChangedPayload                  WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+	WebhookEventUserRoleChangedPayload                   WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+	WebhookEventUserDeletedPayload                       WebhookEventUser[WebhookEventDataEmpty]
+	WebhookEventUserSuspendedChangedPayload              WebhookEventUser[WebhookEventDataSimpleBoolUpdate]
+	WebhookEventUserTagsChangedPayload                   WebhookEventUser[WebhookEventDataTagsChanged]
+	WebhookEventUserTimeZoneChangedPayload               WebhookEventUser[WebhookEventDataSimpleStringUpdate]
+)
 
-type WebhookEventOrganizationCreatedPayload WebhookEventOrganization[WebhookEventDataEmpty]
-type WebhookEventOrganizationCustomFieldChangedPayload WebhookEventOrganization[WebhookEventDataCustomFieldUpdate]
-type WebhookEventOrganizationDeletedPayload WebhookEventOrganization[WebhookEventDataEmpty]
-type WebhookEventOrganizationExternalIDChangedPayload WebhookEventOrganization[WebhookEventDataSimpleStringUpdate]
-type WebhookEventOrganizationNameChangedPayload WebhookEventOrganization[WebhookEventDataSimpleStringUpdate]
-type WebhookEventOrganizationTagsChangedPayload WebhookEventOrganization[WebhookEventDataTagsChanged]
+type (
+	WebhookEventOrganizationCreatedPayload            WebhookEventOrganization[WebhookEventDataEmpty]
+	WebhookEventOrganizationCustomFieldChangedPayload WebhookEventOrganization[WebhookEventDataCustomFieldUpdate]
+	WebhookEventOrganizationDeletedPayload            WebhookEventOrganization[WebhookEventDataEmpty]
+	WebhookEventOrganizationExternalIDChangedPayload  WebhookEventOrganization[WebhookEventDataSimpleStringUpdate]
+	WebhookEventOrganizationNameChangedPayload        WebhookEventOrganization[WebhookEventDataSimpleStringUpdate]
+	WebhookEventOrganizationTagsChangedPayload        WebhookEventOrganization[WebhookEventDataTagsChanged]
+)
 
-type WebhookEventArticlePublishedPayload WebhookEventArticle[any]
-type WebhookEventArticleSubscriptionCreatedPayload WebhookEventArticle[any]
-type WebhookEventArticleUnpublishedPayload WebhookEventArticle[any]
-type WebhookEventArticleVoteCreatedPayload WebhookEventArticle[any]
-type WebhookEventArticleVoteChangedPayload WebhookEventArticle[any]
-type WebhookEventArticleVoteRemovedPayload WebhookEventArticle[any]
-type WebhookEventArticleCommentCreatedPayload WebhookEventArticle[any]
-type WebhookEventArticleCommentChangedPayload WebhookEventArticle[any]
-type WebhookEventArticleCommentPublishedPayload WebhookEventArticle[any]
-type WebhookEventArticleCommentUnpublishedPayload WebhookEventArticle[any]
-type WebhookEventArticleAuthorChangedPayload WebhookEventArticle[any]
+type (
+	WebhookEventArticlePublishedPayload           WebhookEventArticle[any]
+	WebhookEventArticleSubscriptionCreatedPayload WebhookEventArticle[any]
+	WebhookEventArticleUnpublishedPayload         WebhookEventArticle[any]
+	WebhookEventArticleVoteCreatedPayload         WebhookEventArticle[any]
+	WebhookEventArticleVoteChangedPayload         WebhookEventArticle[any]
+	WebhookEventArticleVoteRemovedPayload         WebhookEventArticle[any]
+	WebhookEventArticleCommentCreatedPayload      WebhookEventArticle[any]
+	WebhookEventArticleCommentChangedPayload      WebhookEventArticle[any]
+	WebhookEventArticleCommentPublishedPayload    WebhookEventArticle[any]
+	WebhookEventArticleCommentUnpublishedPayload  WebhookEventArticle[any]
+	WebhookEventArticleAuthorChangedPayload       WebhookEventArticle[any]
+)
 
-type WebhookEventCommunityPostCreatedPayload WebhookEventCommunityPost[any]
-type WebhookEventCommunityPostChangedPayload WebhookEventCommunityPost[any]
-type WebhookEventCommunityPostPublishedPayload WebhookEventCommunityPost[any]
-type WebhookEventCommunityPostUnpublishedPayload WebhookEventCommunityPost[any]
-type WebhookEventCommunityPostSubscriptionCreatedPayload WebhookEventCommunityPost[any]
-type WebhookEventCommunityPostVoteCreatedPayload WebhookEventCommunityPost[any]
-type WebhookEventCommunityPostVoteChangedPayload WebhookEventCommunityPost[any]
-type WebhookEventCommunityPostVoteRemovedPayload WebhookEventCommunityPost[any]
-type WebhookEventCommunityPostCommentCreatedPayload WebhookEventCommunityPost[any]
-type WebhookEventCommunityPostCommentChangedPayload WebhookEventCommunityPost[any]
-type WebhookEventCommunityPostCommentPublishedPayload WebhookEventCommunityPost[any]
-type WebhookEventCommunityPostCommentUnpublishedPayload WebhookEventCommunityPost[any]
-type WebhookEventCommunityPostCommentVoteCreatedPayload WebhookEventCommunityPost[any]
-type WebhookEventCommunityPostCommentVoteChangedPayload WebhookEventCommunityPost[any]
+type (
+	WebhookEventCommunityPostCreatedPayload             WebhookEventCommunityPost[any]
+	WebhookEventCommunityPostChangedPayload             WebhookEventCommunityPost[any]
+	WebhookEventCommunityPostPublishedPayload           WebhookEventCommunityPost[any]
+	WebhookEventCommunityPostUnpublishedPayload         WebhookEventCommunityPost[any]
+	WebhookEventCommunityPostSubscriptionCreatedPayload WebhookEventCommunityPost[any]
+	WebhookEventCommunityPostVoteCreatedPayload         WebhookEventCommunityPost[any]
+	WebhookEventCommunityPostVoteChangedPayload         WebhookEventCommunityPost[any]
+	WebhookEventCommunityPostVoteRemovedPayload         WebhookEventCommunityPost[any]
+	WebhookEventCommunityPostCommentCreatedPayload      WebhookEventCommunityPost[any]
+	WebhookEventCommunityPostCommentChangedPayload      WebhookEventCommunityPost[any]
+	WebhookEventCommunityPostCommentPublishedPayload    WebhookEventCommunityPost[any]
+	WebhookEventCommunityPostCommentUnpublishedPayload  WebhookEventCommunityPost[any]
+	WebhookEventCommunityPostCommentVoteCreatedPayload  WebhookEventCommunityPost[any]
+	WebhookEventCommunityPostCommentVoteChangedPayload  WebhookEventCommunityPost[any]
+)
 
-type WebhookEventAgentStateChangedPayload WebhookEventAgentState[any]
-type WebhookEventAgentWorkItemAddedPayload WebhookEventAgentState[any]
-type WebhookEventAgentWorkItemRemovedPayload WebhookEventAgentState[any]
-type WebhookEventAgentMaxCapacityChangedPayload WebhookEventAgentState[any]
-type WebhookEventAgentUnifiedStateChangedPayload WebhookEventAgentState[any]
-type WebhookEventAgentChannelCreatedPayload WebhookEventAgentState[any]
-type WebhookEventAgentChannelDeletedPayload WebhookEventAgentState[any]
+type (
+	WebhookEventAgentStateChangedPayload        WebhookEventAgentState[any]
+	WebhookEventAgentWorkItemAddedPayload       WebhookEventAgentState[any]
+	WebhookEventAgentWorkItemRemovedPayload     WebhookEventAgentState[any]
+	WebhookEventAgentMaxCapacityChangedPayload  WebhookEventAgentState[any]
+	WebhookEventAgentUnifiedStateChangedPayload WebhookEventAgentState[any]
+	WebhookEventAgentChannelCreatedPayload      WebhookEventAgentState[any]
+	WebhookEventAgentChannelDeletedPayload      WebhookEventAgentState[any]
+)
 
 type WebhookEventOmnichannelRoutingConfigFeatureChangedPayload WebhookEventOmnichannelRoutingConfig[any]

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -2,6 +2,7 @@ package zendesk
 
 import (
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -113,77 +114,91 @@ const (
 	WebhookEventOmnichannelRoutingConfigFeatureChanged WebhookEventType = "zen:event-type:omnichannel_config.omnichannel_routing_feature_changed"
 )
 
+const (
+	WebhookEventTypePrefixAgentState        string = "zen:event-type:agent"
+	WebhookEventTypePrefixUser              string = "zen:event-type:user"
+	WebhookEventTypePrefixOrganization      string = "zen:event-type:organization"
+	WebhookEventTypePrefixCommunityPost     string = "zen:event-type:community_post"
+	WebhookEventTypePrefixOmnichannelConfig string = "zen:event-type:omnichannel_config"
+	WebhookEventTypePrefixArticle           string = "zen:event-type:article"
+)
+
 type WebhookEventHandlers struct {
-	WebhookEventArticlePublished           func(eventData WebhookEventArticlePublishedPayload) error           ``
-	WebhookEventArticleSubscriptionCreated func(eventData WebhookEventArticleSubscriptionCreatedPayload) error ``
-	WebhookEventArticleUnpublished         func(eventData WebhookEventArticleUnpublishedPayload) error         ``
-	WebhookEventArticleVoteCreated         func(eventData WebhookEventArticleVoteCreatedPayload) error         ``
-	WebhookEventArticleVoteChanged         func(eventData WebhookEventArticleVoteChangedPayload) error         ``
-	WebhookEventArticleVoteRemoved         func(eventData WebhookEventArticleVoteRemovedPayload) error         ``
-	WebhookEventArticleCommentCreated      func(eventData WebhookEventArticleCommentCreatedPayload) error      ``
-	WebhookEventArticleCommentChanged      func(eventData WebhookEventArticleCommentChangedPayload) error      ``
-	WebhookEventArticleCommentPublished    func(eventData WebhookEventArticleCommentPublishedPayload) error    ``
-	WebhookEventArticleCommentUnpublished  func(eventData WebhookEventArticleCommentUnpublishedPayload) error  ``
+	WebhookEventArticlePublished           func(ctx context.Context, eventData WebhookEventArticlePublishedPayload) error
+	WebhookEventArticleSubscriptionCreated func(ctx context.Context, eventData WebhookEventArticleSubscriptionCreatedPayload) error
+	WebhookEventArticleUnpublished         func(ctx context.Context, eventData WebhookEventArticleUnpublishedPayload) error
+	WebhookEventArticleVoteCreated         func(ctx context.Context, eventData WebhookEventArticleVoteCreatedPayload) error
+	WebhookEventArticleVoteChanged         func(ctx context.Context, eventData WebhookEventArticleVoteChangedPayload) error
+	WebhookEventArticleVoteRemoved         func(ctx context.Context, eventData WebhookEventArticleVoteRemovedPayload) error
+	WebhookEventArticleCommentCreated      func(ctx context.Context, eventData WebhookEventArticleCommentCreatedPayload) error
+	WebhookEventArticleCommentChanged      func(ctx context.Context, eventData WebhookEventArticleCommentChangedPayload) error
+	WebhookEventArticleCommentPublished    func(ctx context.Context, eventData WebhookEventArticleCommentPublishedPayload) error
+	WebhookEventArticleCommentUnpublished  func(ctx context.Context, eventData WebhookEventArticleCommentUnpublishedPayload) error
+	WebhookEventArticleDefault             func(ctx context.Context, webhookBody []byte) error
 
-	WebhookEventOrganizationCreated            func(eventData WebhookEventOrganizationCreatedPayload) error            ``
-	WebhookEventOrganizationCustomFieldChanged func(eventData WebhookEventOrganizationCustomFieldChangedPayload) error ``
-	WebhookEventOrganizationDeleted            func(eventData WebhookEventOrganizationDeletedPayload) error            ``
-	WebhookEventOrganizationExternalIDChanged  func(eventData WebhookEventOrganizationExternalIDChangedPayload) error  ``
-	WebhookEventOrganizationNameChanged        func(eventData WebhookEventOrganizationNameChangedPayload) error        ``
-	WebhookEventOrganizationTagsChanged        func(eventData WebhookEventOrganizationTagsChangedPayload) error        ``
+	WebhookEventOrganizationCreated            func(ctx context.Context, eventData WebhookEventOrganizationCreatedPayload) error
+	WebhookEventOrganizationCustomFieldChanged func(ctx context.Context, eventData WebhookEventOrganizationCustomFieldChangedPayload) error
+	WebhookEventOrganizationDeleted            func(ctx context.Context, eventData WebhookEventOrganizationDeletedPayload) error
+	WebhookEventOrganizationExternalIDChanged  func(ctx context.Context, eventData WebhookEventOrganizationExternalIDChangedPayload) error
+	WebhookEventOrganizationNameChanged        func(ctx context.Context, eventData WebhookEventOrganizationNameChangedPayload) error
+	WebhookEventOrganizationTagsChanged        func(ctx context.Context, eventData WebhookEventOrganizationTagsChangedPayload) error
+	WebhookEventOrganizationDefault            func(ctx context.Context, webhookBody []byte) error
 
-	WebhookEventUserAliasChanged                  func(eventData WebhookEventUserAliasChangedPayload) error                  ``
-	WebhookEventUserCreated                       func(eventData WebhookEventUserCreatedPayload) error                       `zenevent:"zen:event-type:user.created"`
-	WebhookEventUserCustomFieldChanged            func(eventData WebhookEventUserCustomFieldChangedPayload) error            `zenevent:"zen:event-type:user.custom_field_changed"`
-	WebhookEventUserCustomRoleChanged             func(eventData WebhookEventUserCustomRoleChangedPayload) error             ``
-	WebhookEventUserDefaultGroupChanged           func(eventData WebhookEventUserDefaultGroupChangedPayload) error           ``
-	WebhookEventUserDetailsChanged                func(eventData WebhookEventUserDetailsChangedPayload) error                ``
-	WebhookEventUserExternalIDChanged             func(eventData WebhookEventUserExternalIDChangedPayload) error             ``
-	WebhookEventUserGroupMembershipCreated        func(eventData WebhookEventUserGroupMembershipCreatedPayload) error        ``
-	WebhookEventUserGroupMembershipDeleted        func(eventData WebhookEventUserGroupMembershipDeletedPayload) error        ``
-	WebhookEventUserIdentityChanged               func(eventData WebhookEventUserIdentityChangedPayload) error               ``
-	WebhookEventUserIdentityCreated               func(eventData WebhookEventUserIdentityCreatedPayload) error               ``
-	WebhookEventUserIdentityDeleted               func(eventData WebhookEventUserIdentityDeletedPayload) error               ``
-	WebhookEventUserActiveChanged                 func(eventData WebhookEventUserActiveChangedPayload) error                 ``
-	WebhookEventUserLastLoginChanged              func(eventData WebhookEventUserLastLoginChangedPayload) error              ``
-	WebhookEventUserMerged                        func(eventData WebhookEventUserMergedPayload) error                        ``
-	WebhookEventUserNameChanged                   func(eventData WebhookEventUserNameChangedPayload) error                   ``
-	WebhookEventUserNotesChanged                  func(eventData WebhookEventUserNotesChangedPayload) error                  ``
-	WebhookEventUserOnlyPrivateCommentsChanged    func(eventData WebhookEventUserOnlyPrivateCommentsChangedPayload) error    ``
-	WebhookEventUserOrganizationMembershipCreated func(eventData WebhookEventUserOrganizationMembershipCreatedPayload) error ``
-	WebhookEventUserOrganizationMembershipDeleted func(eventData WebhookEventUserOrganizationMembershipDeletedPayload) error ``
-	WebhookEventUserPasswordChanged               func(eventData WebhookEventUserPasswordChangedPayload) error               ``
-	WebhookEventUserPhotoChanged                  func(eventData WebhookEventUserPhotoChangedPayload) error                  ``
-	WebhookEventUserRoleChanged                   func(eventData WebhookEventUserRoleChangedPayload) error                   ``
-	WebhookEventUserDeleted                       func(eventData WebhookEventUserDeletedPayload) error                       ``
-	WebhookEventUserSuspendedChanged              func(eventData WebhookEventUserSuspendedChangedPayload) error              ``
-	WebhookEventUserTagsChanged                   func(eventData WebhookEventUserTagsChangedPayload) error                   ``
-	WebhookEventUserTimeZoneChanged               func(eventData WebhookEventUserTimeZoneChangedPayload) error               ``
+	WebhookEventUserAliasChanged                  func(ctx context.Context, eventData WebhookEventUserAliasChangedPayload) error
+	WebhookEventUserCreated                       func(ctx context.Context, eventData WebhookEventUserCreatedPayload) error
+	WebhookEventUserCustomFieldChanged            func(ctx context.Context, eventData WebhookEventUserCustomFieldChangedPayload) error
+	WebhookEventUserCustomRoleChanged             func(ctx context.Context, eventData WebhookEventUserCustomRoleChangedPayload) error
+	WebhookEventUserDefaultGroupChanged           func(ctx context.Context, eventData WebhookEventUserDefaultGroupChangedPayload) error
+	WebhookEventUserDetailsChanged                func(ctx context.Context, eventData WebhookEventUserDetailsChangedPayload) error
+	WebhookEventUserExternalIDChanged             func(ctx context.Context, eventData WebhookEventUserExternalIDChangedPayload) error
+	WebhookEventUserGroupMembershipCreated        func(ctx context.Context, eventData WebhookEventUserGroupMembershipCreatedPayload) error
+	WebhookEventUserGroupMembershipDeleted        func(ctx context.Context, eventData WebhookEventUserGroupMembershipDeletedPayload) error
+	WebhookEventUserIdentityChanged               func(ctx context.Context, eventData WebhookEventUserIdentityChangedPayload) error
+	WebhookEventUserIdentityCreated               func(ctx context.Context, eventData WebhookEventUserIdentityCreatedPayload) error
+	WebhookEventUserIdentityDeleted               func(ctx context.Context, eventData WebhookEventUserIdentityDeletedPayload) error
+	WebhookEventUserActiveChanged                 func(ctx context.Context, eventData WebhookEventUserActiveChangedPayload) error
+	WebhookEventUserLastLoginChanged              func(ctx context.Context, eventData WebhookEventUserLastLoginChangedPayload) error
+	WebhookEventUserMerged                        func(ctx context.Context, eventData WebhookEventUserMergedPayload) error
+	WebhookEventUserNameChanged                   func(ctx context.Context, eventData WebhookEventUserNameChangedPayload) error
+	WebhookEventUserNotesChanged                  func(ctx context.Context, eventData WebhookEventUserNotesChangedPayload) error
+	WebhookEventUserOnlyPrivateCommentsChanged    func(ctx context.Context, eventData WebhookEventUserOnlyPrivateCommentsChangedPayload) error
+	WebhookEventUserOrganizationMembershipCreated func(ctx context.Context, eventData WebhookEventUserOrganizationMembershipCreatedPayload) error
+	WebhookEventUserOrganizationMembershipDeleted func(ctx context.Context, eventData WebhookEventUserOrganizationMembershipDeletedPayload) error
+	WebhookEventUserPasswordChanged               func(ctx context.Context, eventData WebhookEventUserPasswordChangedPayload) error
+	WebhookEventUserPhotoChanged                  func(ctx context.Context, eventData WebhookEventUserPhotoChangedPayload) error
+	WebhookEventUserRoleChanged                   func(ctx context.Context, eventData WebhookEventUserRoleChangedPayload) error
+	WebhookEventUserDeleted                       func(ctx context.Context, eventData WebhookEventUserDeletedPayload) error
+	WebhookEventUserSuspendedChanged              func(ctx context.Context, eventData WebhookEventUserSuspendedChangedPayload) error
+	WebhookEventUserTagsChanged                   func(ctx context.Context, eventData WebhookEventUserTagsChangedPayload) error
+	WebhookEventUserTimeZoneChanged               func(ctx context.Context, eventData WebhookEventUserTimeZoneChangedPayload) error
+	WebhookEventUserDefault                       func(ctx context.Context, webhookBody []byte) error
 
-	WebhookEventCommunityPostCreated             func(eventData WebhookEventCommunityPostCreatedPayload) error             ``
-	WebhookEventCommunityPostChanged             func(eventData WebhookEventCommunityPostChangedPayload) error             ``
-	WebhookEventCommunityPostPublished           func(eventData WebhookEventCommunityPostPublishedPayload) error           ``
-	WebhookEventCommunityPostUnpublished         func(eventData WebhookEventCommunityPostUnpublishedPayload) error         ``
-	WebhookEventCommunityPostSubscriptionCreated func(eventData WebhookEventCommunityPostSubscriptionCreatedPayload) error ``
-	WebhookEventCommunityPostVoteCreated         func(eventData WebhookEventCommunityPostVoteCreatedPayload) error         ``
-	WebhookEventCommunityPostVoteChanged         func(eventData WebhookEventCommunityPostVoteChangedPayload) error         ``
-	WebhookEventCommunityPostVoteRemoved         func(eventData WebhookEventCommunityPostVoteRemovedPayload) error         ``
-	WebhookEventCommunityPostCommentCreated      func(eventData WebhookEventCommunityPostCommentCreatedPayload) error      ``
-	WebhookEventCommunityPostCommentChanged      func(eventData WebhookEventCommunityPostCommentChangedPayload) error      ``
-	WebhookEventCommunityPostCommentPublished    func(eventData WebhookEventCommunityPostCommentPublishedPayload) error    ``
-	WebhookEventCommunityPostCommentUnpublished  func(eventData WebhookEventCommunityPostCommentUnpublishedPayload) error  ``
-	WebhookEventCommunityPostCommentVoteCreated  func(eventData WebhookEventCommunityPostCommentVoteCreatedPayload) error  ``
-	WebhookEventCommunityPostCommentVoteChanged  func(eventData WebhookEventCommunityPostCommentVoteChangedPayload) error  ``
+	WebhookEventCommunityPostCreated             func(ctx context.Context, eventData WebhookEventCommunityPostCreatedPayload) error
+	WebhookEventCommunityPostChanged             func(ctx context.Context, eventData WebhookEventCommunityPostChangedPayload) error
+	WebhookEventCommunityPostPublished           func(ctx context.Context, eventData WebhookEventCommunityPostPublishedPayload) error
+	WebhookEventCommunityPostUnpublished         func(ctx context.Context, eventData WebhookEventCommunityPostUnpublishedPayload) error
+	WebhookEventCommunityPostSubscriptionCreated func(ctx context.Context, eventData WebhookEventCommunityPostSubscriptionCreatedPayload) error
+	WebhookEventCommunityPostVoteCreated         func(ctx context.Context, eventData WebhookEventCommunityPostVoteCreatedPayload) error
+	WebhookEventCommunityPostVoteChanged         func(ctx context.Context, eventData WebhookEventCommunityPostVoteChangedPayload) error
+	WebhookEventCommunityPostVoteRemoved         func(ctx context.Context, eventData WebhookEventCommunityPostVoteRemovedPayload) error
+	WebhookEventCommunityPostCommentCreated      func(ctx context.Context, eventData WebhookEventCommunityPostCommentCreatedPayload) error
+	WebhookEventCommunityPostCommentChanged      func(ctx context.Context, eventData WebhookEventCommunityPostCommentChangedPayload) error
+	WebhookEventCommunityPostCommentPublished    func(ctx context.Context, eventData WebhookEventCommunityPostCommentPublishedPayload) error
+	WebhookEventCommunityPostCommentUnpublished  func(ctx context.Context, eventData WebhookEventCommunityPostCommentUnpublishedPayload) error
+	WebhookEventCommunityPostCommentVoteCreated  func(ctx context.Context, eventData WebhookEventCommunityPostCommentVoteCreatedPayload) error
+	WebhookEventCommunityPostCommentVoteChanged  func(ctx context.Context, eventData WebhookEventCommunityPostCommentVoteChangedPayload) error
+	WebhookEventCommunityPostDefault             func(ctx context.Context, webhookBody []byte) error
 
-	WebhookEventAgentStateChanged        func(eventData WebhookEventAgentStateChangedPayload) error        ``
-	WebhookEventAgentWorkItemAdded       func(eventData WebhookEventAgentWorkItemAddedPayload) error       ``
-	WebhookEventAgentWorkItemRemoved     func(eventData WebhookEventAgentWorkItemRemovedPayload) error     ``
-	WebhookEventAgentMaxCapacityChanged  func(eventData WebhookEventAgentMaxCapacityChangedPayload) error  ``
-	WebhookEventAgentUnifiedStateChanged func(eventData WebhookEventAgentUnifiedStateChangedPayload) error ``
-	WebhookEventAgentChannelCreated      func(eventData WebhookEventAgentChannelCreatedPayload) error      ``
-	WebhookEventAgentChannelDeleted      func(eventData WebhookEventAgentChannelDeletedPayload) error      ``
+	WebhookEventAgentStateChanged        func(ctx context.Context, eventData WebhookEventAgentStateChangedPayload) error
+	WebhookEventAgentWorkItemAdded       func(ctx context.Context, eventData WebhookEventAgentWorkItemAddedPayload) error
+	WebhookEventAgentWorkItemRemoved     func(ctx context.Context, eventData WebhookEventAgentWorkItemRemovedPayload) error
+	WebhookEventAgentMaxCapacityChanged  func(ctx context.Context, eventData WebhookEventAgentMaxCapacityChangedPayload) error
+	WebhookEventAgentUnifiedStateChanged func(ctx context.Context, eventData WebhookEventAgentUnifiedStateChangedPayload) error
+	WebhookEventAgentChannelCreated      func(ctx context.Context, eventData WebhookEventAgentChannelCreatedPayload) error
+	WebhookEventAgentChannelDeleted      func(ctx context.Context, eventData WebhookEventAgentChannelDeletedPayload) error
+	WebhookEventAgentDefault             func(ctx context.Context, webhookBody []byte) error
 
-	WebhookEventOmnichannelRoutingConfigFeatureChanged func(eventData WebhookEventOmnichannelRoutingConfigFeatureChangedPayload) error ``
+	WebhookEventOmnichannelRoutingConfigFeatureChanged func(ctx context.Context, eventData WebhookEventOmnichannelRoutingConfigFeatureChangedPayload) error
 }
 
 // Base webhookevent for Event Based webhooks.
@@ -198,37 +213,11 @@ type WebhookEvent struct {
 	Detail              any              `json:"detail"`
 }
 
-type WebhookHandlerOptions struct {
-	webhookSigningSecret string
-}
-
-type WebhookHandlerModifier interface {
-	ModifyWebhookRequest(webhookHandlerOptions *WebhookHandlerOptions)
-}
-
-type webhookRequestModifier func(webhookHandlerOptions *WebhookHandlerOptions)
-
-func (w webhookRequestModifier) ModifyWebhookRequest(webhookHandlerOptions *WebhookHandlerOptions) {
-	w(webhookHandlerOptions)
-}
-
-func WithSigningSecret(webhookSigningSecret string) webhookRequestModifier {
-	return webhookRequestModifier(func(webhookHandlerOptions *WebhookHandlerOptions) {
-		webhookHandlerOptions.webhookSigningSecret = webhookSigningSecret
-	})
-}
-
 //gocyclo:ignore
 func (s *WebhookService) HandleWebhookEvent(
 	eventHandlers WebhookEventHandlers,
-	modifiers ...WebhookHandlerModifier,
+	webhookSigningSecret string,
 ) http.Handler {
-	// Handle adding Authentication Methods and Verification Signature Secret
-	webhookHandlerOptions := WebhookHandlerOptions{}
-	for _, modifier := range modifiers {
-		modifier.ModifyWebhookRequest(&webhookHandlerOptions)
-	}
-
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		webhookBody, err := readWebhookBody(r)
 		if err != nil {
@@ -250,12 +239,10 @@ func (s *WebhookService) HandleWebhookEvent(
 			return
 		}
 
-		if webhookHandlerOptions.webhookSigningSecret != "" {
-			if !s.verifyZendeskWebhookSignatureIsValid(r, webhookBody, webhookHandlerOptions.webhookSigningSecret) {
-				respondToWebhookRequest(w, http.StatusBadRequest, "Bad Request")
+		if !s.verifyZendeskWebhookSignatureIsValid(r, webhookBody, webhookSigningSecret) {
+			respondToWebhookRequest(w, http.StatusBadRequest, "Bad Request")
 
-				return
-			}
+			return
 		}
 
 		switch baseTarget.Type {
@@ -269,7 +256,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventArticlePublished(target); err != nil {
+				if err := eventHandlers.WebhookEventArticlePublished(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -288,7 +275,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventArticleSubscriptionCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleSubscriptionCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -307,7 +294,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventArticleUnpublished(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleUnpublished(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -326,7 +313,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventArticleVoteCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleVoteCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -345,7 +332,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventArticleVoteChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleVoteChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -364,7 +351,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventArticleVoteRemoved(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleVoteRemoved(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -383,7 +370,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventArticleCommentCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleCommentCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -402,7 +389,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventArticleCommentChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleCommentChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -421,7 +408,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventArticleCommentPublished(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleCommentPublished(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -440,7 +427,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventArticleCommentUnpublished(target); err != nil {
+				if err := eventHandlers.WebhookEventArticleCommentUnpublished(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -461,7 +448,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventOrganizationCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventOrganizationCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -480,7 +467,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventOrganizationCustomFieldChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventOrganizationCustomFieldChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -499,7 +486,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventOrganizationDeleted(target); err != nil {
+				if err := eventHandlers.WebhookEventOrganizationDeleted(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -518,7 +505,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventOrganizationExternalIDChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventOrganizationExternalIDChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -537,7 +524,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventOrganizationNameChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventOrganizationNameChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -556,7 +543,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventOrganizationTagsChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventOrganizationTagsChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -577,7 +564,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserAliasChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserAliasChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -596,7 +583,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventUserCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -615,7 +602,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserCustomFieldChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserCustomFieldChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -634,7 +621,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserCustomRoleChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserCustomRoleChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -653,7 +640,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserDefaultGroupChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserDefaultGroupChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -672,7 +659,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserDetailsChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserDetailsChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -691,7 +678,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserExternalIDChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserExternalIDChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -710,7 +697,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserGroupMembershipCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventUserGroupMembershipCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -729,7 +716,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserGroupMembershipDeleted(target); err != nil {
+				if err := eventHandlers.WebhookEventUserGroupMembershipDeleted(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -748,7 +735,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserIdentityChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserIdentityChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -767,7 +754,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserIdentityCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventUserIdentityCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -786,7 +773,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserIdentityDeleted(target); err != nil {
+				if err := eventHandlers.WebhookEventUserIdentityDeleted(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -805,7 +792,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserActiveChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserActiveChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -824,7 +811,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserLastLoginChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserLastLoginChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -843,7 +830,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserMerged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserMerged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -862,7 +849,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserNameChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserNameChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -881,7 +868,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserNotesChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserNotesChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -900,7 +887,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserOnlyPrivateCommentsChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserOnlyPrivateCommentsChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -919,7 +906,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserOrganizationMembershipCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventUserOrganizationMembershipCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -938,7 +925,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserOrganizationMembershipDeleted(target); err != nil {
+				if err := eventHandlers.WebhookEventUserOrganizationMembershipDeleted(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -957,7 +944,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserPasswordChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserPasswordChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -976,7 +963,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserPhotoChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserPhotoChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -995,7 +982,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserRoleChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserRoleChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1014,7 +1001,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserDeleted(target); err != nil {
+				if err := eventHandlers.WebhookEventUserDeleted(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1034,7 +1021,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserSuspendedChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserSuspendedChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1053,7 +1040,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserTagsChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserTagsChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1072,7 +1059,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventUserTimeZoneChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventUserTimeZoneChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1093,7 +1080,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1112,7 +1099,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1131,7 +1118,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostPublished(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostPublished(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1150,7 +1137,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostUnpublished(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostUnpublished(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1169,7 +1156,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostSubscriptionCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostSubscriptionCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1188,7 +1175,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostVoteCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostVoteCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1207,7 +1194,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostVoteChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostVoteChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1226,7 +1213,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostVoteRemoved(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostVoteRemoved(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1245,7 +1232,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostCommentCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCommentCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1264,7 +1251,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostCommentChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCommentChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1283,7 +1270,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostCommentPublished(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCommentPublished(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1302,7 +1289,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostCommentUnpublished(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCommentUnpublished(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1321,7 +1308,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostCommentVoteCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCommentVoteCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1340,7 +1327,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventCommunityPostCommentVoteChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventCommunityPostCommentVoteChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1361,7 +1348,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventAgentStateChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentStateChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1380,7 +1367,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventAgentWorkItemAdded(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentWorkItemAdded(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1399,7 +1386,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventAgentWorkItemRemoved(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentWorkItemRemoved(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1418,7 +1405,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventAgentMaxCapacityChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentMaxCapacityChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1437,7 +1424,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventAgentUnifiedStateChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentUnifiedStateChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1456,7 +1443,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventAgentChannelCreated(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentChannelCreated(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1475,11 +1462,11 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventAgentChannelDeleted(target); err != nil {
+				if err := eventHandlers.WebhookEventAgentChannelDeleted(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
-						err.Error(),
+						"There was a server error processing the request",
 					)
 
 					return
@@ -1496,7 +1483,7 @@ func (s *WebhookService) HandleWebhookEvent(
 					return
 				}
 
-				if err := eventHandlers.WebhookEventOmnichannelRoutingConfigFeatureChanged(target); err != nil {
+				if err := eventHandlers.WebhookEventOmnichannelRoutingConfigFeatureChanged(r.Context(), target); err != nil {
 					respondToWebhookRequest(
 						w,
 						http.StatusInternalServerError,
@@ -1522,15 +1509,9 @@ func (s *WebhookService) HandleWebhookEvent(
 }
 
 func (s *WebhookService) HandleWebhookTrigger(
-	handler func(b []byte) error,
-	modifiers ...WebhookHandlerModifier,
+	handler func(ctx context.Context, webhookBody []byte) error,
+	webhookSigningSecret string,
 ) http.Handler {
-	// Handle adding Authentication Methods and Verification Signature Secret
-	webhookHandlerOptions := WebhookHandlerOptions{}
-	for _, modifier := range modifiers {
-		modifier.ModifyWebhookRequest(&webhookHandlerOptions)
-	}
-
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		webhookBody, err := readWebhookBody(r)
 		if err != nil {
@@ -1539,16 +1520,14 @@ func (s *WebhookService) HandleWebhookTrigger(
 			return
 		}
 
-		if webhookHandlerOptions.webhookSigningSecret != "" {
-			if !s.verifyZendeskWebhookSignatureIsValid(r, webhookBody, webhookHandlerOptions.webhookSigningSecret) {
-				respondToWebhookRequest(w, http.StatusBadRequest, "Bad Request")
+		if !s.verifyZendeskWebhookSignatureIsValid(r, webhookBody, webhookSigningSecret) {
+			respondToWebhookRequest(w, http.StatusBadRequest, "Bad Request")
 
-				return
-			}
+			return
 		}
 
 		if handler != nil {
-			if err := handler(webhookBody); err != nil {
+			if err := handler(r.Context(), webhookBody); err != nil {
 				respondToWebhookRequest(w, http.StatusInternalServerError, err.Error())
 
 				return

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -30,9 +30,26 @@ const (
 	// Other webhook events...
 )
 
-// https://support.zendesk.com/hc/en-us/articles/4408839108378-Creating-webhooks-to-interact-with-third-party-systems#ariaid-title4
-// NOTE: For Webhookss connected to Triggers or Automations, any structure can be defined by a Zendesk Administrator for the payload
-type WebhookTriggerEvent any
+type WebhookEventHandlers struct {
+	WebhookEventArticleAuthorChanged func(event WebhookEventArticleAuthorChanged)
+}
+
+func (s WebhookService) WebhookEvent(handlers WebhookEventHandlers, secret string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// TODO: auth and unmarshal - hand wavy part
+
+		if subject && handlers.EventTypeArticleAuthorChanged != nil {
+			handlers.UserEvent(Event[User]{})
+			return
+		}
+	})
+}
+
+func (s WebhookService) WebhookTrigger(handler func(b []byte), secret string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+	})
+}
 
 func (s WebhookService) HandleWebhook(
 	processor func(requestBody []byte) error,
@@ -156,15 +173,15 @@ func readWebhookBody(r *http.Request) ([]byte, error) {
 }
 
 // https://developer.zendesk.com/api-reference/webhooks/event-types/webhook-event-types/
-type WebhookEvent[Detail any, Event any] struct {
-	Type                WebhookEventType `json:"type"`
-	AccountID           AccountID        `json:"account_id"`
-	ID                  WebhookEventID   `json:"id"`
-	Time                time.Time        `json:"time"`
-	ZendeskEventVersion string           `json:"zendesk_event_version"`
-	Subject             string           `json:"subject"`
-	Event               Event            `json:"event"`
-	Detail              Detail           `json:"detail"`
+type WebhookEventArticle[Event any] struct {
+	Type                WebhookEventType          `json:"type"`
+	AccountID           AccountID                 `json:"account_id"`
+	ID                  WebhookEventID            `json:"id"`
+	Time                time.Time                 `json:"time"`
+	ZendeskEventVersion string                    `json:"zendesk_event_version"`
+	Subject             string                    `json:"subject"`
+	Event               Event                     `json:"event"`
+	Detail              WebhookEventArticleDetail `json:"detail"`
 }
 
 // https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/
@@ -173,17 +190,22 @@ type WebhookEventArticleDetail struct {
 	ID      ArticleID `json:"id"`
 }
 
-type WebhookEventArticleAuthorChanged WebhookEvent[EventTypeArticleAuthorChangedEvent, EventTypeArticleAuthorChangedDetail]
-type EventTypeArticleAuthorChangedEvent struct{}
-type EventTypeArticleAuthorChangedDetail struct{}
-
-type WebhookEventUser[EventData WebhookUserEventData] struct {
-	WebhookEvent
-	Event  EventData              `json:"event"`
-	Detail WebhookEventDetailUser `json:"detail"`
+type WebhookEventArticleAuthorChanged WebhookEventArticle[EventTypeArticleAuthorChangedEvent]
+type EventTypeArticleAuthorChangedEvent struct {
 }
 
-type WebhookEventDetailUser struct {
+type WebhookEventUser[Event any] struct {
+	Type                WebhookEventType       `json:"type"`
+	AccountID           AccountID              `json:"account_id"`
+	ID                  WebhookEventID         `json:"id"`
+	Time                time.Time              `json:"time"`
+	ZendeskEventVersion string                 `json:"zendesk_event_version"`
+	Subject             string                 `json:"subject"`
+	Event               Event                  `json:"event"`
+	Detail              WebhookEventUserDetail `json:"detail"`
+}
+
+type WebhookEventUserDetail struct {
 	CreatedAt      time.Time    `json:"created_at"`
 	Email          string       `json:"email"`
 	ExternalID     string       `json:"external_id"`
@@ -192,27 +214,6 @@ type WebhookEventDetailUser struct {
 	OrganizationID string       `json:"organization_id"`
 	Role           CustomRoleID `json:"role"`
 	UpdatedAt      time.Time    `json:"updated_at"`
-}
-
-type WebhookEventHandlers struct {
-	EventTypeArticleAuthorChanged func(event EventTypeArticleAuthorChanged)
-}
-
-func (s WebhookService) WebhookEvent(handlers WebhookEventHandlers, secret string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// TODO: auth and unmarshal - hand wavy part
-
-		if subject && handlers.EventTypeArticleAuthorChanged != nil {
-			handlers.UserEvent(Event[User]{})
-			return
-		}
-	})
-}
-
-func (s WebhookService) WebhookTrigger(handler func(b []byte), secret string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
-	})
 }
 
 // type WebhookEventUser[Event WebhookUserEventData] struct {

--- a/zendesk/webhook.go
+++ b/zendesk/webhook.go
@@ -19,67 +19,93 @@ type WebhookService struct {
 }
 
 type WebhookEventHandlers struct {
-	UserEventHandler                     func(e WebhookEventUser) error
-	ArticleEventHandler                  func(e WebhookEventArticle) error
-	OrganizationEventHandler             func(e WebhookEventOrganization) error
-	CommunityPostEventHandler            func(e WebhookEventCommunityPost) error
-	AgentAvailabilityEventHandler        func(e WebhookEventAgentAvailability) error
-	OmnichannelRoutingConfigEventHandler func(e WebhookEventOmnichannelRoutingConfig) error
+	DefaultUserEventHandler func(e WebhookEventUser, webhookSecret string) error
+	UserEventHandlers       map[WebhookEventTypePrefix]func(e WebhookEventUser, webhookSecret string) error
+	// UserEventHandler                     func(e WebhookEventUser) error
+	// ArticleEventHandler                  func(e WebhookEventArticle) error
+	// OrganizationEventHandler             func(e WebhookEventOrganization) error
+	// CommunityPostEventHandler            func(e WebhookEventCommunityPost) error
+	// AgentAvailabilityEventHandler        func(e WebhookEventAgentAvailability) error
+	// OmnichannelRoutingConfigEventHandler func(e WebhookEventOmnichannelRoutingConfig) error
+
 }
 
-func (s WebhookService) HandleWebhookUserEvent(
-	webhookSecret string,
-	userEventProcessor func(e WebhookEventUser) error,
-) http.Handler {
-	return s.VerifyZendeskWebhook(
-		webhookSecret,
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			bodyBytes, err := readWebhookBody(r)
-			if err != nil {
-				respondJSON(
-					w,
-					http.StatusInternalServerError,
-					"Could not read Webhook Request body",
-				)
+type WebhookEventType string
 
-				return
-			}
+const (
+	WebhookEventTrigger                  WebhookEventType = "trigger_or_automation"
+	WebhookEventUserActive               WebhookEventType = "zen:event-type:user.active_changed"
+	WebhookEventOmnichannelConfigFeature WebhookEventType = "zen:event-type:omnichannel_config.omnichannel_routing_feature_changed"
+	// Other webhook events...
+)
 
-			eventType, err := validateWebhookEvent(bodyBytes, WebhookEventUserPrefix)
-			if err != nil {
-				respondJSON(
-					w,
-					http.StatusInternalServerError,
-					"Could not read Webhook Request body",
-				)
+// https://support.zendesk.com/hc/en-us/articles/4408839108378-Creating-webhooks-to-interact-with-third-party-systems#ariaid-title4
+// NOTE: For Webhookss connected to Triggers or Automations, any structure can be defined by a Zendesk Administrator for the payload
+type WebhookTriggerEvent any
 
-				return
-			}
+type WebhookEventTypePrefix string
 
-			// Get the userevent struct
-			e := WebhookEventUser{}
+const (
+	WebhookEventTypePrefixUser WebhookEventTypePrefix = "zen:event-type:user"
+)
 
-			if err := userEventProcessor(e); err != nil {
-				respondJSON(
-					w,
-					http.StatusInternalServerError,
-					"Unsuccessful handling of Webhook Request",
-				)
+func (s WebhookService) HandleWebhook(w http.ResponseWriter, r *http.Request) http.Handler {
 
-				return
-			}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-			respondJSON(
-				w,
-				http.StatusOK,
-				"Successfully handled Webhook Request",
-			)
-		}),
-	)
+	})
 }
+
+// func (s WebhookService) HandleWebhookUserEvent() http.Handler {
+// 	return s.VerifyZendeskWebhook(
+// 		webhookSecret,
+// 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 			bodyBytes, err := readWebhookBody(r)
+// 			if err != nil {
+// 				respondJSON(
+// 					w,
+// 					http.StatusInternalServerError,
+// 					"Could not read Webhook Request body",
+// 				)
+
+// 				return
+// 			}
+
+// 			eventType, err := validateWebhookEvent(bodyBytes, WebhookEventUserPrefix)
+// 			if err != nil {
+// 				respondJSON(
+// 					w,
+// 					http.StatusInternalServerError,
+// 					"Could not read Webhook Request body",
+// 				)
+
+// 				return
+// 			}
+
+// 			// Get the userevent struct
+// 			e := WebhookEventUser{}
+
+// 			if err := userEventProcessor(e); err != nil {
+// 				respondJSON(
+// 					w,
+// 					http.StatusInternalServerError,
+// 					"Unsuccessful handling of Webhook Request",
+// 				)
+
+// 				return
+// 			}
+
+// 			respondJSON(
+// 				w,
+// 				http.StatusOK,
+// 				"Successfully handled Webhook Request",
+// 			)
+// 		}),
+// 	)
+// }
 
 // https://developer.zendesk.com/documentation/webhooks/verifying/
-func (s WebhookService) VerifyZendeskWebhook(webhookSecret string, next http.Handler) http.Handler {
+func (s WebhookService) VerifyZendeskWebhook(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -156,37 +182,6 @@ func readWebhookBody(r *http.Request) ([]byte, error) {
 	return bodyBytes, nil
 }
 
-func validateWebhookEvent(webhookPayload []byte) bool {
-	target := WebhookEvent{}
-	if err := json.Unmarshal(webhookPayload, &target); err != nil {
-		return "", err
-	}
-
-	if target.Type != "" {
-		return target.Type, nil
-	}
-
-	return WebhookEventTrigger, nil
-}
-
-type WebhookEventType string
-
-const (
-	WebhookEventTrigger                  WebhookEventType = "trigger_or_automation"
-	WebhookEventUserActive               WebhookEventType = "zen:event-type:user.active_changed"
-	WebhookEventOmnichannelConfigFeature WebhookEventType = "zen:event-type:omnichannel_config.omnichannel_routing_feature_changed"
-	// Other webhook events...
-)
-
-const (
-	WebhookEventUserPrefix              string = "zen:event-type:user"
-	WebhookEventOmnichannelConfigPrefix string = "zen:event-type:omnichannel_config"
-)
-
-// https://support.zendesk.com/hc/en-us/articles/4408839108378-Creating-webhooks-to-interact-with-third-party-systems#ariaid-title4
-// NOTE: For Webhookss connected to Triggers or Automations, any structure can be defined by a Zendesk Administrator for the payload
-type WebhookTriggerEvent any
-
 // https://developer.zendesk.com/api-reference/webhooks/event-types/webhook-event-types/
 type WebhookEvent struct {
 	Type                WebhookEventType `json:"type"`
@@ -229,25 +224,28 @@ type WebhookEventDetailUser struct {
 	UpdatedAt      time.Time    `json:"updated_at"`
 }
 
+// https://developer.zendesk.com/api-reference/webhooks/event-types/community-events/
 type WebhookEventCommunityPost struct {
 	Detail WebhookEventDetailCommunityPost `json:"detail"`
 	Event  any                             `json:"event"`
 	WebhookEvent
 }
 
-// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
+// https://developer.zendesk.com/api-reference/webhooks/event-types/community-events/#detail-object-properties
 type WebhookEventDetailCommunityPost struct {
 	BrandID BrandID `json:"brand_id"`
 	PostID  PostID  `json:"post_id"`
 	TopicID TopicID `json:"topic_id"`
 }
 
+// https://developer.zendesk.com/api-reference/webhooks/event-types/organization-events/
 type WebhookEventOrganization struct {
 	Detail WebhookEventDetailOrganization `json:"detail"`
 	Event  any                            `json:"event"`
 	WebhookEvent
 }
 
+// https://developer.zendesk.com/api-reference/webhooks/event-types/organization-events/#detail-object-properties
 type WebhookEventDetailOrganization struct {
 	CreatedAt      time.Time `json:"created_at"`
 	ExternalID     *string   `json:"external_id"`
@@ -259,26 +257,28 @@ type WebhookEventDetailOrganization struct {
 	UpdatedAt      time.Time `json:"updated_at"`
 }
 
+// https://developer.zendesk.com/api-reference/webhooks/event-types/omnichannel-routing-configuration-events/
 type WebhookEventOmnichannelRoutingConfig struct {
 	Detail WebhookEventDetailOmnichannelRoutingConfig `json:"detail"`
 	Event  any                                        `json:"event"`
 	WebhookEvent
 }
 
+// https://developer.zendesk.com/api-reference/webhooks/event-types/omnichannel-routing-configuration-events/#detail-object-properties
+type WebhookEventDetailOmnichannelRoutingConfig struct {
+	AccountID AccountID `json:"account_id"`
+}
+
+// https://developer.zendesk.com/api-reference/webhooks/event-types/agent-availability-events/
 type WebhookEventAgentAvailability struct {
 	Detail WebhookEventDetailAgentAvailability `json:"detail"`
 	Event  any                                 `json:"event"`
 	WebhookEvent
 }
 
-// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
+// https://developer.zendesk.com/api-reference/webhooks/event-types/agent-availability-events/#detail-object-properties
 type WebhookEventDetailAgentAvailability struct {
 	AccountID AccountID `json:"account_id"`
 	AgentID   string    `json:"agent_id"`
 	Version   string    `json:"version"`
-}
-
-// https://developer.zendesk.com/api-reference/webhooks/event-types/article-events/#detail-object-properties
-type WebhookEventDetailOmnichannelRoutingConfig struct {
-	AccountID AccountID `json:"account_id"`
 }

--- a/zendesk/webhook_test.go
+++ b/zendesk/webhook_test.go
@@ -4,41 +4,44 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/aaronellington/zendesk-go/zendesk"
 	"github.com/aaronellington/zendesk-go/zendesk/internal/study"
 )
 
-func Test_WebhookVerification_200(t *testing.T) {
+// https://developer.zendesk.com/documentation/webhooks/verifying/#signing-secrets-on-new-webhooks
+const ZendeskTestStaticWebhookSignature string = "dGhpc19zZWNyZXRfaXNfZm9yX3Rlc3Rpbmdfb25seQ=="
+
+func Test_WebhookVerifySignature_200(t *testing.T) {
 	ctx := context.Background()
 
-	z := createTestService(t, []study.RoundTripFunc{
-		study.ServeAndValidate(
-			t,
-			&study.TestResponseFile{
-				StatusCode: http.StatusOK,
-				FilePath:   "test_files/responses/support/users/show_200.json",
-			},
-			study.ExpectedTestRequest{
-				Method: http.MethodGet,
-				Path:   "/api/v2/users/1000",
-			},
-		),
-	})
+	z := createTestService(t, []study.RoundTripFunc{})
+	recorder := httptest.NewRecorder()
+	requestFile, _ := os.Open("test_requests/zendeskGroupMembershipCreate.json")
+	// testRequest := httptest.NewRequest(http.MethodPost, "/webhook/zendesk/event", requestFile)
 
-	actualEventData := zendesk.WebhookEventUser{}
-
-	recorder := httptest.NewRecorder
-	handler := z.Webhook().HandleWebhookUserEvent(
-		"secret",
-		func(e zendesk.WebhookEventUser) error {
-			if e.Detail.Email != "cgibson@datto.com" {
-				t.Fatal("did not match")
-				return
-			}
-
-		},
+	testRequest, _ := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		"/webhook/zendesk/event",
+		requestFile,
 	)
+	testRequest.Header.Set(zendesk.WebhookHeaderSignature, ZendeskTestStaticWebhookSignature)
+	testRequest.Header.Set(zendesk.WebhookHeaderSignature, "1234")
 
+	z.Webhook().HandleWebhook(
+		func(requestBody []byte) error {
+			return nil
+		},
+		"soemthing",
+	).ServeHTTP(recorder, testRequest)
+
+	response := recorder.Result()
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatal(response.StatusCode)
+	}
 }

--- a/zendesk/webhook_test.go
+++ b/zendesk/webhook_test.go
@@ -13,7 +13,7 @@ import (
 
 const ZendeskTestStaticWebhookSignature string = "dGhpc19zZWNyZXRfaXNfZm9yX3Rlc3Rpbmdfb25seQ=="
 
-func Test_WebhookVerifySignature_200(t *testing.T) {
+func Test_WebhookEventVerifySignature_200(t *testing.T) {
 	ctx := context.Background()
 
 	z := createTestService(t, []study.RoundTripFunc{})
@@ -46,7 +46,7 @@ func Test_WebhookVerifySignature_200(t *testing.T) {
 	}
 }
 
-func Test_WebhookSkipVerifySignature_200(t *testing.T) {
+func Test_WebhookEventSkipVerifySignature_200(t *testing.T) {
 	ctx := context.Background()
 
 	z := createTestService(t, []study.RoundTripFunc{})
@@ -68,6 +68,37 @@ func Test_WebhookSkipVerifySignature_200(t *testing.T) {
 				return nil
 			},
 		},
+	).ServeHTTP(recorder, testRequest)
+
+	response := recorder.Result()
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatal(response.StatusCode)
+	}
+}
+
+func Test_WebhookTriggerVerifySignature_200(t *testing.T) {
+	ctx := context.Background()
+
+	z := createTestService(t, []study.RoundTripFunc{})
+	recorder := httptest.NewRecorder()
+	requestFile, _ := os.Open("test_files/requests/webhook/trigger/ticket_update.json")
+
+	testRequest, _ := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		"/webhook/zendesk/trigger",
+		requestFile,
+	)
+	testRequest.Header.Set(zendesk.WebhookHeaderSignature, "PlxjkFT3fSnU9NWSRjLHP86izLX68auazS1Xo8ZfiZE=")
+	testRequest.Header.Set(zendesk.WebhookHeaderSignatureTimestamp, "1234")
+
+	z.Webhook().HandleWebhookTrigger(
+		func(b []byte) error {
+			return nil
+		},
+		zendesk.WithSigningSecret(ZendeskTestStaticWebhookSignature),
 	).ServeHTTP(recorder, testRequest)
 
 	response := recorder.Result()

--- a/zendesk/webhook_test.go
+++ b/zendesk/webhook_test.go
@@ -31,43 +31,11 @@ func Test_WebhookEventVerifySignature_200(t *testing.T) {
 
 	z.Webhook().HandleWebhookEvent(
 		zendesk.WebhookEventHandlers{
-			WebhookEventUserGroupMembershipCreated: func(eventData zendesk.WebhookEventUserGroupMembershipCreatedPayload) error {
+			WebhookEventUserGroupMembershipCreated: func(ctx context.Context, eventData zendesk.WebhookEventUserGroupMembershipCreatedPayload) error {
 				return nil
 			},
 		},
-		zendesk.WithSigningSecret(ZendeskTestStaticWebhookSignature),
-	).ServeHTTP(recorder, testRequest)
-
-	response := recorder.Result()
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		t.Fatal(response.StatusCode)
-	}
-}
-
-func Test_WebhookEventSkipVerifySignature_200(t *testing.T) {
-	ctx := context.Background()
-
-	z := createTestService(t, []study.RoundTripFunc{})
-	recorder := httptest.NewRecorder()
-	requestFile, _ := os.Open("test_files/requests/webhook/user/group_membership_created.json")
-
-	testRequest, _ := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		"/webhook/zendesk/event",
-		requestFile,
-	)
-	testRequest.Header.Set(zendesk.WebhookHeaderSignature, "10IqYzYTLHRftNsNE+im0DeOM6/JactIRuy0XCHJ9B8=")
-	testRequest.Header.Set(zendesk.WebhookHeaderSignatureTimestamp, "1234")
-
-	z.Webhook().HandleWebhookEvent(
-		zendesk.WebhookEventHandlers{
-			WebhookEventUserGroupMembershipCreated: func(eventData zendesk.WebhookEventUserGroupMembershipCreatedPayload) error {
-				return nil
-			},
-		},
+		ZendeskTestStaticWebhookSignature,
 	).ServeHTTP(recorder, testRequest)
 
 	response := recorder.Result()
@@ -95,10 +63,10 @@ func Test_WebhookTriggerVerifySignature_200(t *testing.T) {
 	testRequest.Header.Set(zendesk.WebhookHeaderSignatureTimestamp, "1234")
 
 	z.Webhook().HandleWebhookTrigger(
-		func(b []byte) error {
+		func(ctx context.Context, b []byte) error {
 			return nil
 		},
-		zendesk.WithSigningSecret(ZendeskTestStaticWebhookSignature),
+		ZendeskTestStaticWebhookSignature,
 	).ServeHTTP(recorder, testRequest)
 
 	response := recorder.Result()

--- a/zendesk/webhook_test.go
+++ b/zendesk/webhook_test.go
@@ -1,47 +1,47 @@
 package zendesk_test
 
-import (
-	"context"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"testing"
+// import (
+// 	"context"
+// 	"net/http"
+// 	"net/http/httptest"
+// 	"os"
+// 	"testing"
 
-	"github.com/aaronellington/zendesk-go/zendesk"
-	"github.com/aaronellington/zendesk-go/zendesk/internal/study"
-)
+// 	"github.com/aaronellington/zendesk-go/zendesk"
+// 	"github.com/aaronellington/zendesk-go/zendesk/internal/study"
+// )
 
-// https://developer.zendesk.com/documentation/webhooks/verifying/#signing-secrets-on-new-webhooks
-const ZendeskTestStaticWebhookSignature string = "dGhpc19zZWNyZXRfaXNfZm9yX3Rlc3Rpbmdfb25seQ=="
+// // https://developer.zendesk.com/documentation/webhooks/verifying/#signing-secrets-on-new-webhooks
+// const ZendeskTestStaticWebhookSignature string = "dGhpc19zZWNyZXRfaXNfZm9yX3Rlc3Rpbmdfb25seQ=="
 
-func Test_WebhookVerifySignature_200(t *testing.T) {
-	ctx := context.Background()
+// func Test_WebhookVerifySignature_200(t *testing.T) {
+// 	ctx := context.Background()
 
-	z := createTestService(t, []study.RoundTripFunc{})
-	recorder := httptest.NewRecorder()
-	requestFile, _ := os.Open("test_requests/zendeskGroupMembershipCreate.json")
-	// testRequest := httptest.NewRequest(http.MethodPost, "/webhook/zendesk/event", requestFile)
+// 	z := createTestService(t, []study.RoundTripFunc{})
+// 	recorder := httptest.NewRecorder()
+// 	requestFile, _ := os.Open("test_requests/zendeskGroupMembershipCreate.json")
+// 	// testRequest := httptest.NewRequest(http.MethodPost, "/webhook/zendesk/event", requestFile)
 
-	testRequest, _ := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		"/webhook/zendesk/event",
-		requestFile,
-	)
-	testRequest.Header.Set(zendesk.WebhookHeaderSignature, ZendeskTestStaticWebhookSignature)
-	testRequest.Header.Set(zendesk.WebhookHeaderSignature, "1234")
+// 	testRequest, _ := http.NewRequestWithContext(
+// 		ctx,
+// 		http.MethodPost,
+// 		"/webhook/zendesk/event",
+// 		requestFile,
+// 	)
+// 	testRequest.Header.Set(zendesk.WebhookHeaderSignature, ZendeskTestStaticWebhookSignature)
+// 	testRequest.Header.Set(zendesk.WebhookHeaderSignature, "1234")
 
-	z.Webhook().HandleWebhook(
-		func(requestBody []byte) error {
-			return nil
-		},
-		"soemthing",
-	).ServeHTTP(recorder, testRequest)
+// 	z.Webhook().HandleWebhook(
+// 		func(requestBody []byte) error {
+// 			return nil
+// 		},
+// 		"soemthing",
+// 	).ServeHTTP(recorder, testRequest)
 
-	response := recorder.Result()
-	defer response.Body.Close()
+// 	response := recorder.Result()
+// 	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
-		t.Fatal(response.StatusCode)
-	}
-}
+// 	if response.StatusCode != http.StatusOK {
+// 		t.Fatal(response.StatusCode)
+// 	}
+// }

--- a/zendesk/webhook_test.go
+++ b/zendesk/webhook_test.go
@@ -1,0 +1,44 @@
+package zendesk_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aaronellington/zendesk-go/zendesk"
+	"github.com/aaronellington/zendesk-go/zendesk/internal/study"
+)
+
+func Test_WebhookVerification_200(t *testing.T) {
+	ctx := context.Background()
+
+	z := createTestService(t, []study.RoundTripFunc{
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusOK,
+				FilePath:   "test_files/responses/support/users/show_200.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodGet,
+				Path:   "/api/v2/users/1000",
+			},
+		),
+	})
+
+	actualEventData := zendesk.WebhookEventUser{}
+
+	recorder := httptest.NewRecorder
+	handler := z.Webhook().HandleWebhookUserEvent(
+		"secret",
+		func(e zendesk.WebhookEventUser) error {
+			if e.Detail.Email != "cgibson@datto.com" {
+				t.Fatal("did not match")
+				return
+			}
+
+		},
+	)
+
+}

--- a/zendesk/webhook_test.go
+++ b/zendesk/webhook_test.go
@@ -35,7 +35,7 @@ func Test_WebhookVerifySignature_200(t *testing.T) {
 				return nil
 			},
 		},
-		ZendeskTestStaticWebhookSignature,
+		zendesk.WithSigningSecret(ZendeskTestStaticWebhookSignature),
 	).ServeHTTP(recorder, testRequest)
 
 	response := recorder.Result()
@@ -68,7 +68,6 @@ func Test_WebhookSkipVerifySignature_200(t *testing.T) {
 				return nil
 			},
 		},
-		"",
 	).ServeHTTP(recorder, testRequest)
 
 	response := recorder.Result()

--- a/zendesk/webhook_test.go
+++ b/zendesk/webhook_test.go
@@ -1,47 +1,80 @@
 package zendesk_test
 
-// import (
-// 	"context"
-// 	"net/http"
-// 	"net/http/httptest"
-// 	"os"
-// 	"testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
 
-// 	"github.com/aaronellington/zendesk-go/zendesk"
-// 	"github.com/aaronellington/zendesk-go/zendesk/internal/study"
-// )
+	"github.com/aaronellington/zendesk-go/zendesk"
+	"github.com/aaronellington/zendesk-go/zendesk/internal/study"
+)
 
-// // https://developer.zendesk.com/documentation/webhooks/verifying/#signing-secrets-on-new-webhooks
-// const ZendeskTestStaticWebhookSignature string = "dGhpc19zZWNyZXRfaXNfZm9yX3Rlc3Rpbmdfb25seQ=="
+const ZendeskTestStaticWebhookSignature string = "dGhpc19zZWNyZXRfaXNfZm9yX3Rlc3Rpbmdfb25seQ=="
 
-// func Test_WebhookVerifySignature_200(t *testing.T) {
-// 	ctx := context.Background()
+func Test_WebhookVerifySignature_200(t *testing.T) {
+	ctx := context.Background()
 
-// 	z := createTestService(t, []study.RoundTripFunc{})
-// 	recorder := httptest.NewRecorder()
-// 	requestFile, _ := os.Open("test_requests/zendeskGroupMembershipCreate.json")
-// 	// testRequest := httptest.NewRequest(http.MethodPost, "/webhook/zendesk/event", requestFile)
+	z := createTestService(t, []study.RoundTripFunc{})
+	recorder := httptest.NewRecorder()
+	requestFile, _ := os.Open("test_files/requests/webhook/user/group_membership_created.json")
 
-// 	testRequest, _ := http.NewRequestWithContext(
-// 		ctx,
-// 		http.MethodPost,
-// 		"/webhook/zendesk/event",
-// 		requestFile,
-// 	)
-// 	testRequest.Header.Set(zendesk.WebhookHeaderSignature, ZendeskTestStaticWebhookSignature)
-// 	testRequest.Header.Set(zendesk.WebhookHeaderSignature, "1234")
+	testRequest, _ := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		"/webhook/zendesk/event",
+		requestFile,
+	)
+	testRequest.Header.Set(zendesk.WebhookHeaderSignature, "10IqYzYTLHRftNsNE+im0DeOM6/JactIRuy0XCHJ9B8=")
+	testRequest.Header.Set(zendesk.WebhookHeaderSignatureTimestamp, "1234")
 
-// 	z.Webhook().HandleWebhook(
-// 		func(requestBody []byte) error {
-// 			return nil
-// 		},
-// 		"soemthing",
-// 	).ServeHTTP(recorder, testRequest)
+	z.Webhook().HandleWebhookEvent(
+		zendesk.WebhookEventHandlers{
+			WebhookEventUserGroupMembershipCreated: func(eventData zendesk.WebhookEventUserGroupMembershipCreatedPayload) error {
+				return nil
+			},
+		},
+		ZendeskTestStaticWebhookSignature,
+	).ServeHTTP(recorder, testRequest)
 
-// 	response := recorder.Result()
-// 	defer response.Body.Close()
+	response := recorder.Result()
+	defer response.Body.Close()
 
-// 	if response.StatusCode != http.StatusOK {
-// 		t.Fatal(response.StatusCode)
-// 	}
-// }
+	if response.StatusCode != http.StatusOK {
+		t.Fatal(response.StatusCode)
+	}
+}
+
+func Test_WebhookSkipVerifySignature_200(t *testing.T) {
+	ctx := context.Background()
+
+	z := createTestService(t, []study.RoundTripFunc{})
+	recorder := httptest.NewRecorder()
+	requestFile, _ := os.Open("test_files/requests/webhook/user/group_membership_created.json")
+
+	testRequest, _ := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		"/webhook/zendesk/event",
+		requestFile,
+	)
+	testRequest.Header.Set(zendesk.WebhookHeaderSignature, "10IqYzYTLHRftNsNE+im0DeOM6/JactIRuy0XCHJ9B8=")
+	testRequest.Header.Set(zendesk.WebhookHeaderSignatureTimestamp, "1234")
+
+	z.Webhook().HandleWebhookEvent(
+		zendesk.WebhookEventHandlers{
+			WebhookEventUserGroupMembershipCreated: func(eventData zendesk.WebhookEventUserGroupMembershipCreatedPayload) error {
+				return nil
+			},
+		},
+		"",
+	).ServeHTTP(recorder, testRequest)
+
+	response := recorder.Result()
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatal(response.StatusCode)
+	}
+}


### PR DESCRIPTION
### Add new feature - Handle incoming webhook requests
This PR allows a user to set a callback function for each Event Webhook, and interact with the payload data. Optional webhook signing secret to ensure request integrity is supported. 

Authentication is not supported. 
Configuration of webhooks is not supported.