### PR TITLE
Resolve Error.Immutable() function not returning correct value and slightly refactor Tag functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ full: clean lint test build
 ## Build the project
 build:
 
-## Test the project
+## Test the zendesk package only. Do not include 'internal' or 'example' pacakages
 test: test-go
 
 test-go:
 	@mkdir -p var/coverage/go/
 	@go install github.com/boumenot/gocover-cobertura@latest
-	go test -p 1 -count=1 -cover -coverprofile var/coverage/go/profile.txt ./...
+	go test -p 1 -count=1 -cover -coverprofile var/coverage/go/profile.txt ./zendesk
 	@go tool cover -func var/coverage/go/profile.txt | awk '/^total/{print $$1 " " $$3}'
 	@go tool cover -html var/coverage/go/profile.txt -o var/coverage/go/coverage.html
 	@gocover-cobertura < var/coverage/go/profile.txt > var/coverage/go/cobertura-coverage.xml

--- a/zendesk/client.go
+++ b/zendesk/client.go
@@ -76,7 +76,7 @@ func (c *client) doWithRetry(request *http.Request, target any) error {
 		}
 
 		// Check for a "retry-after" header and then continue
-		retryAfterString := zendeskErr.Response.Header.Get("retry-after")
+		retryAfterString := zendeskErr.Response.Header.Get("Retry-After")
 		if retryAfterString != "" {
 			var err error
 

--- a/zendesk/client_test.go
+++ b/zendesk/client_test.go
@@ -3,6 +3,7 @@ package zendesk_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -13,6 +14,46 @@ import (
 	"github.com/aaronellington/zendesk-go/zendesk"
 	"github.com/aaronellington/zendesk-go/zendesk/internal/study"
 )
+
+func Test_Client_422(t *testing.T) {
+	ctx := context.Background()
+	closedTicketID := zendesk.TicketID(1000)
+
+	z := createTestService(t, []study.RoundTripFunc{
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusUnprocessableEntity,
+				FilePath:   "test_files/responses/errors/422_record_invalid.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodPut,
+				Path:   fmt.Sprintf("/api/v2/tickets/%d", closedTicketID),
+			},
+		),
+	})
+
+	_, err := z.Support().Tickets().Update(ctx, closedTicketID, zendesk.TicketPayload{
+		Ticket: zendesk.TicketComment{
+			Body: "This is a test comment, which is being added to a closed ticket.",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected an error - did not receive one")
+	}
+
+	zendeskGoError := &zendesk.Error{}
+	isZendeskGoError := errors.As(err, &zendeskGoError)
+
+	if !isZendeskGoError {
+		t.Fatalf("expected a custom zendesk-go error, got: %v", err)
+	}
+
+	// Check to confirm that we got a 422 error
+	if !zendeskGoError.ImmutableRecord() {
+		t.Fatal("did not receive an immutable error")
+	}
+}
 
 func Test_Client_429(t *testing.T) {
 	ctx := context.Background()

--- a/zendesk/error.go
+++ b/zendesk/error.go
@@ -22,11 +22,8 @@ func (err *Error) Error() string {
 }
 
 func (err *Error) ImmutableRecord() bool {
-	if err.Message == "RecordInvalid" {
-		return true
-	}
-
-	if err.Message == "RecordNotFound" {
+	if strings.HasPrefix(err.Message, "RecordInvalid") ||
+		strings.HasPrefix(err.Message, "RecordNotFound") {
 		return true
 	}
 

--- a/zendesk/service.go
+++ b/zendesk/service.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const DefaultHTTPClientTimeout = time.Second * 15
+
 func NewService(
 	subDomain string,
 	zendeskAuth authentication,
@@ -14,7 +16,7 @@ func NewService(
 ) *Service {
 	config := &internalConfig{
 		userAgent: "aaronellington/zendesk-go",
-		timeout:   time.Second * 15,
+		timeout:   DefaultHTTPClientTimeout,
 	}
 	for _, opt := range opts {
 		opt(config)

--- a/zendesk/support_ticket_management_tag.go
+++ b/zendesk/support_ticket_management_tag.go
@@ -1,13 +1,17 @@
 package zendesk
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"unicode/utf8"
 )
+
+const minimumTagNameForSearch = int(2)
 
 // https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags
 type TicketTagService struct {
@@ -16,19 +20,34 @@ type TicketTagService struct {
 
 type Tag string
 
+type TagsPayload struct {
+	Tags Tags `json:"tags"`
+}
+
+type Tags []Tag
+
+func (tags Tags) HasTag(targetTag Tag) bool {
+	for _, tag := range tags {
+		if tag == targetTag {
+			return true
+		}
+	}
+
+	return false
+}
+
 type TagMeta struct {
 	Name  Tag    `json:"name"`
 	Count uint64 `json:"count"`
 }
 
+type TagsSearchResponse struct {
+	Tags Tags `json:"tags"`
+}
+
 type TagsResponse struct {
 	Tags []TagMeta `json:"tags"`
 	CursorPaginationResponse
-}
-
-type TagSearchResponse struct {
-	Tags []Tag `json:"tags"`
-	OffsetPaginationResponse
 }
 
 // https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#list-tags
@@ -74,18 +93,15 @@ func (s TicketTagService) List(
 	return nil
 }
 
-/*
-https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#search-tags
-
-Does not support cursor pagination.
-*/
+// https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#search-tags
 func (s TicketTagService) Search(
 	ctx context.Context,
 	searchTerm string,
-	pageHandler func(response TagSearchResponse) error,
-) error {
-	if utf8.RuneCountInString(searchTerm) < 3 {
-		return errors.New("invalid searchterm - searchterm must be at least 2 characters")
+) (Tags, error) {
+	target := TagsSearchResponse{}
+
+	if validSearchTermSize := utf8.RuneCountInString(searchTerm) >= minimumTagNameForSearch; !validSearchTermSize {
+		return Tags{}, errors.New("invalid request - 'searchTerm' must be at least 2 characters")
 	}
 
 	query := url.Values{}
@@ -95,35 +111,106 @@ func (s TicketTagService) Search(
 		query.Encode(),
 	)
 
-	for {
-		target := TagSearchResponse{}
-
-		request, err := http.NewRequestWithContext(
-			ctx,
-			http.MethodGet,
-			endpoint,
-			http.NoBody,
-		)
-		if err != nil {
-			return err
-		}
-
-		if err := s.client.ZendeskRequest(request, &target); err != nil {
-			return err
-		}
-
-		if err := pageHandler(target); err != nil {
-			return err
-		}
-
-		if target.NextPage != nil {
-			endpoint = *target.NextPage
-
-			continue
-		}
-
-		break
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		endpoint,
+		http.NoBody,
+	)
+	if err != nil {
+		return Tags{}, err
 	}
 
-	return nil
+	if err := s.client.ZendeskRequest(request, &target); err != nil {
+		return Tags{}, err
+	}
+
+	return target.Tags, nil
+}
+
+// https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#set-tags
+func (s TicketService) SetTags(ctx context.Context, ticketID TicketID, tags Tags) (Tags, error) {
+	target := TagsPayload{}
+
+	payloadBuf := new(bytes.Buffer)
+	if err := json.NewEncoder(payloadBuf).Encode(TagsPayload{
+		Tags: tags,
+	}); err != nil {
+		return Tags{}, err
+	}
+
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf("/api/v2/tickets/%d/tags", ticketID),
+		payloadBuf,
+	)
+	if err != nil {
+		return Tags{}, err
+	}
+
+	if err := s.client.ZendeskRequest(request, &target); err != nil {
+		return Tags{}, err
+	}
+
+	return target.Tags, nil
+}
+
+// https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#add-tags
+func (s TicketService) AddTags(ctx context.Context, ticketID TicketID, tags Tags) (Tags, error) {
+	target := TagsPayload{}
+
+	payloadBuf := new(bytes.Buffer)
+	if err := json.NewEncoder(payloadBuf).Encode(TagsPayload{
+		Tags: tags,
+	}); err != nil {
+		return Tags{}, err
+	}
+
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPut,
+		fmt.Sprintf("/api/v2/tickets/%d/tags", ticketID),
+		payloadBuf,
+	)
+	if err != nil {
+		return Tags{}, err
+	}
+
+	if err := s.client.ZendeskRequest(request, &target); err != nil {
+		return Tags{}, err
+	}
+
+	return target.Tags, nil
+}
+
+// https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#remove-tags
+func (s TicketService) RemoveTags(ctx context.Context, ticketID TicketID, tags Tags) (Tags, error) {
+	target := TagsPayload{}
+
+	payloadBuf := new(bytes.Buffer)
+	if err := json.NewEncoder(payloadBuf).Encode(TagsPayload{
+		Tags: tags,
+	}); err != nil {
+		return Tags{}, err
+	}
+
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodDelete,
+		fmt.Sprintf("/api/v2/tickets/%d/tags", ticketID),
+		payloadBuf,
+	)
+	if err != nil {
+		return Tags{}, err
+	}
+
+	if err := s.client.ZendeskRequest(
+		request,
+		&target,
+	); err != nil {
+		return Tags{}, err
+	}
+
+	return target.Tags, nil
 }

--- a/zendesk/support_ticket_management_tag_test.go
+++ b/zendesk/support_ticket_management_tag_test.go
@@ -243,11 +243,10 @@ func Test_SupportTickets_SearchTags_TermShorterThanAllowed(t *testing.T) {
 		t.Fatal("expected to get an error")
 	}
 
-	if err.Error() != "invalid searchterm - 'searchTerm' must be at least 2 characters" {
-		t.Fatalf(
-			"did not get expected error - expected: '%s', got: '%s'",
-			"invalid searchterm - searchterm must be at least 2 characters",
+	if err.Error() != "invalid request - 'searchTerm' must be at least 2 characters" {
+		t.Fatalf("did not get expected error - got: '%s', expected: '%s'",
 			err.Error(),
+			"invalid searchterm - searchterm must be at least 2 characters",
 		)
 	}
 }

--- a/zendesk/support_ticket_management_tag_test.go
+++ b/zendesk/support_ticket_management_tag_test.go
@@ -1,0 +1,253 @@
+package zendesk_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"testing"
+
+	"github.com/aaronellington/zendesk-go/zendesk"
+	"github.com/aaronellington/zendesk-go/zendesk/internal/study"
+)
+
+func Test_SupportTickets_AddTags_200(t *testing.T) {
+	ctx := context.Background()
+	ticketID := zendesk.TicketID(2000)
+	tagToAdd := zendesk.Tag("test_tag_zendesk_go")
+
+	z := createTestService(t, []study.RoundTripFunc{
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusOK,
+				FilePath:   "test_files/responses/support/tickets/add_tags_200.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodPut,
+				Path:   fmt.Sprintf("/api/v2/tickets/%d/tags", ticketID),
+			},
+		),
+	})
+
+	response, err := z.Support().Tickets().AddTags(ctx, ticketID, zendesk.Tags{tagToAdd})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Contains(response, tagToAdd) {
+		t.Fatal("response did not contain tag")
+	}
+}
+
+func Test_SupportTickets_AddTags_422(t *testing.T) {
+	ctx := context.Background()
+	closedTicketID := zendesk.TicketID(2000)
+	tagToAdd := zendesk.Tag("test_tag_zendesk_go")
+
+	z := createTestService(t, []study.RoundTripFunc{
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusUnprocessableEntity,
+				FilePath:   "test_files/responses/support/tickets/add_tags_422.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodPut,
+				Path:   fmt.Sprintf("/api/v2/tickets/%d/tags", closedTicketID),
+			},
+		),
+	})
+
+	_, err := z.Support().Tickets().AddTags(ctx, closedTicketID, zendesk.Tags{tagToAdd})
+	if err == nil {
+		t.Fatal(err)
+	}
+
+	zendeskGoError := &zendesk.Error{}
+	isZendeskGoError := errors.As(err, &zendeskGoError)
+
+	if !isZendeskGoError {
+		t.Fatalf("expected a custom zendesk-go error, got: %v", err)
+	}
+
+	// Check to confirm that we got a 422 error
+	if !zendeskGoError.ImmutableRecord() {
+		t.Fatal("did not receive an immutable error")
+	}
+}
+
+func Test_SupportTickets_RemoveTags_200(t *testing.T) {
+	ctx := context.Background()
+	ticketID := zendesk.TicketID(2000)
+	tagToRemove := zendesk.Tag("test_tag_zendesk_go")
+
+	z := createTestService(t, []study.RoundTripFunc{
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusOK,
+				FilePath:   "test_files/responses/support/tickets/remove_tags_200.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodDelete,
+				Path:   fmt.Sprintf("/api/v2/tickets/%d/tags", ticketID),
+			},
+		),
+	})
+
+	response, err := z.Support().Tickets().RemoveTags(ctx, ticketID, zendesk.Tags{tagToRemove})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if slices.Contains(response, tagToRemove) {
+		t.Fatal("response stil contained tag after update")
+	}
+}
+
+func Test_SupportTickets_RemoveTags_422(t *testing.T) {
+	ctx := context.Background()
+	closedTicketID := zendesk.TicketID(2000)
+	tagToAdd := zendesk.Tag("test_tag_zendesk_go")
+
+	z := createTestService(t, []study.RoundTripFunc{
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusUnprocessableEntity,
+				FilePath:   "test_files/responses/support/tickets/remove_tags_422.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodDelete,
+				Path:   fmt.Sprintf("/api/v2/tickets/%d/tags", closedTicketID),
+			},
+		),
+	})
+
+	_, err := z.Support().Tickets().RemoveTags(ctx, closedTicketID, zendesk.Tags{tagToAdd})
+	if err == nil {
+		t.Fatal(err)
+	}
+
+	zendeskGoError := &zendesk.Error{}
+	isZendeskGoError := errors.As(err, &zendeskGoError)
+
+	if !isZendeskGoError {
+		t.Fatalf("expected a custom zendesk-go error, got: %v", err)
+	}
+
+	// Check to confirm that we got a 422 error
+	if !zendeskGoError.ImmutableRecord() {
+		t.Fatal("did not receive an immutable error")
+	}
+}
+
+func Test_SupportTickets_HasTags_OK(t *testing.T) {
+	targetTag := zendesk.Tag("zendesk_go_is_awesome")
+	tagThatDoesntExist := zendesk.Tag("this_tag_doesnt_exist_on_the_resource")
+
+	tags := zendesk.Tags{
+		"tag_one",
+		"tag_two",
+		targetTag,
+		"AnotherTag",
+		"A_new_random_tag_with_numbers1234",
+	}
+
+	// Assert that we can find the existing Tag in the Tags array
+	if !tags.HasTag(targetTag) {
+		t.Fatal("did not find targetTag in array")
+	}
+
+	// Assert that we do not return true when the Tag does not exist in the Tags array
+	if tags.HasTag(tagThatDoesntExist) {
+		t.Fatal("falsely reporting that tag exists in Tags when it does not")
+	}
+}
+
+func Test_SupportTickets_SearchTags_200(t *testing.T) {
+	searchTerm := "support"
+
+	ctx := context.Background()
+	z := createTestService(t, []study.RoundTripFunc{
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusOK,
+				FilePath:   "test_files/responses/support/tickets/search_tags_200.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodGet,
+				Path:   "/api/v2/autocomplete/tags",
+				Query: url.Values{
+					"name": []string{searchTerm},
+				},
+			},
+		),
+	})
+
+	actualResult, err := z.Support().TicketTags().Search(ctx, searchTerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedResult := zendesk.Tags{
+		"abarcy_support",
+		"abecedarian_support",
+		"abequitate_support",
+		"agelast_premium_support",
+		"acoustic_guitar_free_support",
+		"ameliorate_free_support",
+		"altruistic_free_support",
+		"acquaintances_paid_support",
+		"astronaut_tier_support",
+		"abomination_support",
+		"agoraphobia_inside_only_support",
+		"acquiesce_a_support_survey",
+		"astringent_support",
+		"acerbic_partner_support",
+		"auspicious_ticket_support",
+	}
+
+	if err := study.Assert(expectedResult, actualResult); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func Test_SupportTickets_SearchTags_TermShorterThanAllowed(t *testing.T) {
+	searchTerm := "s"
+
+	ctx := context.Background()
+	z := createTestService(t, []study.RoundTripFunc{
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusOK,
+				FilePath:   "test_files/responses/support/tickets/search_tags_200.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodGet,
+				Path:   "/api/v2/autocomplete/tags",
+				Query: url.Values{
+					"name": []string{searchTerm},
+				},
+			},
+		),
+	})
+
+	_, err := z.Support().TicketTags().Search(ctx, searchTerm)
+	if err == nil {
+		t.Fatal("expected to get an error")
+	}
+
+	if err.Error() != "invalid searchterm - 'searchTerm' must be at least 2 characters" {
+		t.Fatalf(
+			"did not get expected error - expected: '%s', got: '%s'",
+			"invalid searchterm - searchterm must be at least 2 characters",
+			err.Error(),
+		)
+	}
+}

--- a/zendesk/support_tickets.go
+++ b/zendesk/support_tickets.go
@@ -1,9 +1,7 @@
 package zendesk
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -95,22 +93,6 @@ type TicketField struct {
 
 type TicketSatisfactionRating struct {
 	Score string `json:"score"`
-}
-
-type TagsPayload struct {
-	Tags Tags `json:"tags"`
-}
-
-type Tags []Tag
-
-func (tags Tags) HasTag(targetTag Tag) bool {
-	for _, tag := range tags {
-		if tag == targetTag {
-			return true
-		}
-	}
-
-	return false
 }
 
 type TicketsIncrementalExportResponse struct {
@@ -288,93 +270,6 @@ func (s TicketService) IncrementalExport(
 	pageHandler func(response TicketsIncrementalExportResponse) error,
 ) error {
 	return s.IncrementalExportWithSideloads(ctx, startTime, nil, perPage, pageHandler)
-}
-
-// https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#add-tags
-func (s TicketService) AddTags(ctx context.Context, ticketID TicketID, tags Tags) (Tags, error) {
-	target := TagsPayload{}
-
-	payloadBuf := new(bytes.Buffer)
-	if err := json.NewEncoder(payloadBuf).Encode(TagsPayload{
-		Tags: tags,
-	}); err != nil {
-		return Tags{}, err
-	}
-
-	request, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPut,
-		fmt.Sprintf("/api/v2/tickets/%d/tags", ticketID),
-		payloadBuf,
-	)
-	if err != nil {
-		return Tags{}, err
-	}
-
-	if err := s.client.ZendeskRequest(request, &target); err != nil {
-		return Tags{}, err
-	}
-
-	return target.Tags, nil
-}
-
-// https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#set-tags
-func (s TicketService) SetTags(ctx context.Context, ticketID TicketID, tags Tags) (Tags, error) {
-	target := TagsPayload{}
-
-	payloadBuf := new(bytes.Buffer)
-	if err := json.NewEncoder(payloadBuf).Encode(TagsPayload{
-		Tags: tags,
-	}); err != nil {
-		return Tags{}, err
-	}
-
-	request, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		fmt.Sprintf("/api/v2/tickets/%d/tags", ticketID),
-		payloadBuf,
-	)
-	if err != nil {
-		return Tags{}, err
-	}
-
-	if err := s.client.ZendeskRequest(request, &target); err != nil {
-		return Tags{}, err
-	}
-
-	return target.Tags, nil
-}
-
-// https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#remove-tags
-func (s TicketService) RemoveTags(ctx context.Context, ticketID TicketID, tags Tags) (Tags, error) {
-	target := TagsPayload{}
-
-	payloadBuf := new(bytes.Buffer)
-	if err := json.NewEncoder(payloadBuf).Encode(TagsPayload{
-		Tags: tags,
-	}); err != nil {
-		return Tags{}, err
-	}
-
-	request, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodDelete,
-		fmt.Sprintf("/api/v2/tickets/%d/tags", ticketID),
-		payloadBuf,
-	)
-	if err != nil {
-		return Tags{}, err
-	}
-
-	if err := s.client.ZendeskRequest(
-		request,
-		&target,
-	); err != nil {
-		return Tags{}, err
-	}
-
-	return target.Tags, nil
 }
 
 type ListProblemTicketIncidentsResponse struct {

--- a/zendesk/test_files/responses/errors/422_record_invalid.json
+++ b/zendesk/test_files/responses/errors/422_record_invalid.json
@@ -1,0 +1,11 @@
+{
+	"error": "RecordInvalid",
+	"description": "Record validation errors",
+	"details": {
+		"status": [
+			{
+				"description": "Status: closed prevents ticket update"
+			}
+		]
+	}
+}

--- a/zendesk/test_files/responses/support/tickets/add_tags_200.json
+++ b/zendesk/test_files/responses/support/tickets/add_tags_200.json
@@ -1,0 +1,7 @@
+{
+	"tags": [
+		"an_existing_tag_on_ticket",
+		"another_tag_on_ticket",
+		"test_tag_zendesk_go"
+	]
+}

--- a/zendesk/test_files/responses/support/tickets/add_tags_422.json
+++ b/zendesk/test_files/responses/support/tickets/add_tags_422.json
@@ -1,0 +1,11 @@
+{
+	"error": "RecordInvalid",
+	"description": "Record validation errors",
+	"details": {
+		"status": [
+			{
+				"description": "Status: closed prevents ticket update"
+			}
+		]
+	}
+}

--- a/zendesk/test_files/responses/support/tickets/remove_tags_200.json
+++ b/zendesk/test_files/responses/support/tickets/remove_tags_200.json
@@ -1,0 +1,3 @@
+{
+	"tags": ["an_existing_tag_on_ticket", "another_tag_on_ticket"]
+}

--- a/zendesk/test_files/responses/support/tickets/remove_tags_422.json
+++ b/zendesk/test_files/responses/support/tickets/remove_tags_422.json
@@ -1,0 +1,11 @@
+{
+	"error": "RecordInvalid",
+	"description": "Record validation errors",
+	"details": {
+		"status": [
+			{
+				"description": "Status: closed prevents ticket update"
+			}
+		]
+	}
+}

--- a/zendesk/test_files/responses/support/tickets/search_tags_200.json
+++ b/zendesk/test_files/responses/support/tickets/search_tags_200.json
@@ -1,0 +1,19 @@
+{
+	"tags": [
+		"abarcy_support",
+		"abecedarian_support",
+		"abequitate_support",
+		"agelast_premium_support",
+		"acoustic_guitar_free_support",
+		"ameliorate_free_support",
+		"altruistic_free_support",
+		"acquaintances_paid_support",
+		"astronaut_tier_support",
+		"abomination_support",
+		"agoraphobia_inside_only_support",
+		"acquiesce_a_support_survey",
+		"astringent_support",
+		"acerbic_partner_support",
+		"auspicious_ticket_support"
+	]
+}


### PR DESCRIPTION
# Breaking Change
WARNING - this includes a breaking change. The Tag.Search() endpoint was incorrectly documented in the [Zendesk API Reference](https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#search-tags) as supporting Pagination. It does not - it simply returns up to 15 of the most recent tags that contain the search string. 


Change:  
Previous function signature  
```go
func (s TicketTagService) Search(
	ctx context.Context,
	searchTerm string,
	pageHandler func(response TagSearchResponse) error,
) error
```

Proposed function signature  
```go
func (s TicketTagService) Search(
	ctx context.Context,
	searchTerm string,
) (Tags, error) 
```

## Primary Goal  
Resolve issue where the ImmutableRecord() function attached to the custom Error struct was not identifying ImmutableRecords correctly. 

### Main Features

1. Add test coverage for the client, to ensure that we capture desired functionality of the ImmutableRecord function
2. Add tests around some TicketTag functions
3. Refactor the location of the ticket tag functions to a more accurate location