### PR TITLE
Enhancement: Add new endpoint to OrganizationMembership to List Organization Memberships by Organization ID

### DIFF
--- a/zendesk/support_organization_membership.go
+++ b/zendesk/support_organization_membership.go
@@ -83,6 +83,47 @@ func (s OrganizationMembershipService) List(
 	return nil
 }
 
+// https://developer.zendesk.com/api-reference/ticketing/organizations/organization_memberships/#list-memberships
+func (s OrganizationMembershipService) ListByOrganizationID(
+	ctx context.Context,
+	organizationID OrganizationID,
+	pageHandler func(response OrganizationMembershipsResponse) error,
+) error {
+	query := url.Values{}
+	query.Set("page[size]", "100")
+	endpoint := fmt.Sprintf("/api/v2/organizations/%d/organization_memberships?%s", organizationID, query.Encode())
+
+	for {
+		target := OrganizationMembershipsResponse{}
+
+		request, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodGet,
+			endpoint,
+			http.NoBody,
+		)
+		if err != nil {
+			return err
+		}
+
+		if err := s.client.ZendeskRequest(request, &target); err != nil {
+			return err
+		}
+
+		if err := pageHandler(target); err != nil {
+			return err
+		}
+
+		if !target.Meta.HasMore {
+			break
+		}
+
+		endpoint = target.Links.Next
+	}
+
+	return nil
+}
+
 // https://developer.zendesk.com/api-reference/ticketing/organizations/organization_memberships/#show-membership
 func (s OrganizationMembershipService) Show(
 	ctx context.Context,

--- a/zendesk/support_organization_membership_test.go
+++ b/zendesk/support_organization_membership_test.go
@@ -2,6 +2,7 @@ package zendesk_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -78,6 +79,64 @@ func Test_SupportOrganizationMembership_List_200(t *testing.T) {
 	actualMembershipsLen := 0
 
 	if err := z.Support().OrganizationMemberships().List(ctx,
+		func(response zendesk.OrganizationMembershipsResponse) error {
+			for range response.OrganizationMemberships {
+				actualMembershipsLen++
+			}
+
+			return nil
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := study.Assert(expectedMembershipsLen, actualMembershipsLen); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func Test_SupportOrganizationMembership_ListByOrganizationID_200(t *testing.T) {
+	ctx := context.Background()
+	organizationID := zendesk.OrganizationID(12345)
+
+	z := createTestService(t, []study.RoundTripFunc{
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusOK,
+				FilePath:   "test_files/responses/support/organization_membership/list_by_organization_page1_200.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodGet,
+				Path:   fmt.Sprintf("/api/v2/organizations/%d/organization_memberships", organizationID),
+				Query: url.Values{
+					"page[size]": []string{"100"},
+				},
+			},
+		),
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusOK,
+				FilePath:   "test_files/responses/support/organization_membership/list_by_organization_page2_200.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodGet,
+				Path:   fmt.Sprintf("/api/v2/organizations/%d/organization_memberships.json", organizationID),
+				Query: url.Values{
+					"page[size]":  []string{"2"},
+					"page[after]": []string{"aCursor="},
+				},
+			},
+		),
+	})
+
+	expectedMembershipsLen := 4
+	actualMembershipsLen := 0
+
+	if err := z.Support().OrganizationMemberships().ListByOrganizationID(
+		ctx,
+		organizationID,
 		func(response zendesk.OrganizationMembershipsResponse) error {
 			for range response.OrganizationMemberships {
 				actualMembershipsLen++

--- a/zendesk/test_files/responses/support/organization_membership/list_by_organization_page1_200.json
+++ b/zendesk/test_files/responses/support/organization_membership/list_by_organization_page1_200.json
@@ -1,0 +1,35 @@
+{
+    "organization_memberships": [
+        {
+            "url": "https://subdomain.zendesk.com/api/v2/organization_memberships/11230706017820.json",
+            "id": 11230706017820,
+            "user_id": 11230722173724,
+            "organization_id": 12345,
+            "default": true,
+            "created_at": "2023-11-10T15:48:15Z",
+            "organization_name": "End User Organization 1",
+            "updated_at": "2023-11-10T15:48:15Z",
+            "view_tickets": true
+        },
+        {
+            "url": "https://subdomain.zendesk.com/api/v2/organization_memberships/11190962742684.json",
+            "id": 11190962742684,
+            "user_id": 11190946849052,
+            "organization_id": 12345,
+            "default": true,
+            "created_at": "2023-11-08T11:25:45Z",
+            "organization_name": "End User Organization 1",
+            "updated_at": "2023-11-08T11:25:45Z",
+            "view_tickets": true
+        }
+    ],
+    "meta": {
+        "has_more": true,
+        "after_cursor": "aCursor=",
+        "before_cursor": "bCursor="
+    },
+    "links": {
+        "prev": "https://subdomain.zendesk.com/api/v2/organizations/12345/organization_memberships.json?page%5Bbefore%5D=bCursor%3D&page%5Bsize%5D=2",
+        "next": "https://subdomain.zendesk.com/api/v2/organizations/12345/organization_memberships.json?page%5Bafter%5D=aCursor%3D&page%5Bsize%5D=2"
+    }
+}

--- a/zendesk/test_files/responses/support/organization_membership/list_by_organization_page2_200.json
+++ b/zendesk/test_files/responses/support/organization_membership/list_by_organization_page2_200.json
@@ -1,0 +1,35 @@
+{
+    "organization_memberships": [
+        {
+            "url": "https://subdomain.zendesk.com/api/v2/organization_memberships/11224062128028.json",
+            "id": 11224062128028,
+            "user_id": 11224066915868,
+            "organization_id": 12345,
+            "default": true,
+            "created_at": "2023-11-10T10:37:14Z",
+            "organization_name": "End User Organization 1",
+            "updated_at": "2023-11-10T10:37:14Z",
+            "view_tickets": true
+        },
+        {
+            "url": "https://subdomain.zendesk.com/api/v2/organization_memberships/11224116370460.json",
+            "id": 11224116370460,
+            "user_id": 11224066915868,
+            "organization_id": 12345,
+            "default": null,
+            "created_at": "2023-11-10T10:41:29Z",
+            "organization_name": "End User Organization 1",
+            "updated_at": "2023-11-10T10:41:29Z",
+            "view_tickets": true
+        }
+    ],
+    "meta": {
+        "has_more": false,
+        "after_cursor": "cCursor=",
+        "before_cursor": "dCursor="
+    },
+    "links": {
+        "prev": "https://subdomain.zendesk.com/api/v2/organizatios/12345/organization_memberships.json?page%5Bbefore%5D=dCursor%3D&page%5Bsize%5D=2",
+        "next": "https://subdomain.zendesk.com/api/v2/organizatios/12345/organization_memberships.json?page%5Bafter%5D=cCursor%3D&page%5Bsize%5D=2"
+    }
+}


### PR DESCRIPTION
### Enhancement  
Allow users to list Organization Memberships by Organization ID. Currently, the `List` function will list all Organization Memberships for the entire Zendesk subdomain, this improvement will allow users to call the List endpoint with an Organization ID, to limit the results to a single Organization.

The new function is called `ListByOrganizationID`  

Tests confirm the functionality works as expected.  