### PR TITLE
Add additional field and tests for Suspended Ticket endpoints

### DIFF
--- a/zendesk/support_suspended_ticket.go
+++ b/zendesk/support_suspended_ticket.go
@@ -20,6 +20,7 @@ type SuspendedTicket struct {
 	Cause     string                `json:"cause"`
 	Author    SuspendedTicketAuthor `json:"author"`
 	CauseID   int                   `json:"cause_id"`
+	Content   string                `json:"content"`
 	TicketID  *TicketID             `json:"ticket_id"`
 	CreatedAt time.Time             `json:"created_at"`
 	UpdatedAt time.Time             `json:"updated_at"`

--- a/zendesk/support_suspended_ticket.go
+++ b/zendesk/support_suspended_ticket.go
@@ -14,6 +14,10 @@ type SuspendedTicketsResponse struct {
 	CursorPaginationResponse
 }
 
+type SuspendedTicketResponse struct {
+	SuspendedTicket SuspendedTicket `json:"suspended_ticket"`
+}
+
 type SuspendedTicket struct {
 	ID        SuspendedTicketID     `json:"id"`
 	Subject   string                `json:"subject"`
@@ -36,6 +40,30 @@ type SuspendedTicketAuthor struct {
 // https://developer.zendesk.com/api-reference/ticketing/tickets/suspended_tickets/
 type SuspendedTicketService struct {
 	client *client
+}
+
+// https://developer.zendesk.com/api-reference/ticketing/tickets/suspended_tickets/#show-suspended-ticket
+func (s SuspendedTicketService) Show(
+	ctx context.Context,
+	id SuspendedTicketID,
+) (SuspendedTicket, error) {
+	target := SuspendedTicketResponse{}
+
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("/api/v2/suspended_tickets/%d", id),
+		http.NoBody,
+	)
+	if err != nil {
+		return SuspendedTicket{}, err
+	}
+
+	if err := s.client.ZendeskRequest(request, &target); err != nil {
+		return SuspendedTicket{}, err
+	}
+
+	return target.SuspendedTicket, nil
 }
 
 // https://developer.zendesk.com/api-reference/ticketing/tickets/suspended_tickets/#list-suspended-tickets

--- a/zendesk/support_suspended_ticket_test.go
+++ b/zendesk/support_suspended_ticket_test.go
@@ -1,0 +1,119 @@
+package zendesk_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/aaronellington/zendesk-go/zendesk"
+	"github.com/aaronellington/zendesk-go/zendesk/internal/study"
+)
+
+func Test_SupportSuspendedTicket_Show_200(t *testing.T) {
+	ctx := context.Background()
+
+	z := createTestService(t, []study.RoundTripFunc{
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusOK,
+				FilePath:   "test_files/responses/support/suspended_ticket/show_200.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodGet,
+				Path:   "/api/v2/suspended_tickets/12345",
+			},
+		),
+	})
+
+	var exampleSuspendedTicketID zendesk.SuspendedTicketID = 12345
+
+	actual, err := z.Support().SuspendedTickets().Show(ctx, exampleSuspendedTicketID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := study.Assert(exampleSuspendedTicketID, actual.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func Test_SupportSuspendedTicket_List_200(t *testing.T) {
+	ctx := context.Background()
+
+	z := createTestService(t, []study.RoundTripFunc{
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusOK,
+				FilePath:   "test_files/responses/support/suspended_ticket/list_page1_200.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodGet,
+				Path:   "/api/v2/suspended_tickets",
+				Query: url.Values{
+					"page[size]": []string{"100"},
+				},
+			},
+		),
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseFile{
+				StatusCode: http.StatusOK,
+				FilePath:   "test_files/responses/support/suspended_ticket/list_page2_200.json",
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodGet,
+				Path:   "/api/v2/suspended_tickets.json",
+				Query: url.Values{
+					"page[size]":  []string{"1"},
+					"page[after]": []string{"aCursor"},
+				},
+			},
+		),
+	})
+
+	expectedSuspendedTicketsLen := 2
+	actualSuspendedTicketsLen := 0
+
+	if err := z.Support().SuspendedTickets().List(ctx,
+		func(response zendesk.SuspendedTicketsResponse) error {
+			for range response.SuspendedTickets {
+				actualSuspendedTicketsLen++
+			}
+
+			return nil
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := study.Assert(expectedSuspendedTicketsLen, actualSuspendedTicketsLen); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func Test_SupportSuspendedTicket_Delete_200(t *testing.T) {
+	ctx := context.Background()
+
+	var exampleSuspendedTicketID zendesk.SuspendedTicketID = 12345
+
+	z := createTestService(t, []study.RoundTripFunc{
+		study.ServeAndValidate(
+			t,
+			&study.TestResponseNoContent{
+				StatusCode: http.StatusNoContent,
+			},
+			study.ExpectedTestRequest{
+				Method: http.MethodDelete,
+				Path:   fmt.Sprintf("/api/v2/suspended_tickets/%d", exampleSuspendedTicketID),
+			},
+		),
+	})
+
+	if err := z.Support().SuspendedTickets().Delete(ctx, exampleSuspendedTicketID); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/zendesk/test_files/responses/support/suspended_ticket/list_page1_200.json
+++ b/zendesk/test_files/responses/support/suspended_ticket/list_page1_200.json
@@ -1,81 +1,81 @@
 {
-    "suspended_tickets": [
-        {
-            "url": "https://kaseya.zendesk.com/api/v2/suspended_tickets/12345.json",
-            "id": 12345,
-            "author": {
-                "id": null,
-                "name": "Kylo Ren",
-                "email": "KyloRen@stars.com"
-            },
-            "subject": "RE: Support #67894 - product running out of space",
-            "content": "some sort of content",
-            "cause": "User must sign up to submit email; user notified",
-            "cause_id": 12,
-            "error_messages": null,
-            "message_id": "<124ASDJHASF1283AH@TADBA.SOMETHING.prod.outlook.com>",
-            "ticket_id": 67894,
-            "created_at": "2024-05-29T01:09:12Z",
-            "updated_at": "2024-05-29T01:09:12Z",
-            "via": {
-                "channel": "email",
-                "source": {
-                    "from": {
-                        "address": "KyloRen@stars.com",
-                        "name": "Kylo Ren"
-                    },
-                    "to": {
-                        "name": "Subdomain Support",
-                        "address": "support@subdomain.zendesk.com"
-                    },
-                    "rel": null
-                }
-            },
-            "attachments": [
-                {
-                    "url": "https://subdomain.zendesk.com/api/v2/attachments/12345.json",
-                    "id": 12345,
-                    "file_name": "12345.png",
-                    "content_url": "https://subdomain.zendesk.com/attachments/token/GwOoaOOleBcS0UdPnFoXwgrnM/?name=image923295.png",
-                    "mapped_content_url": "https://helpdesk.subdomain.com/attachments/token/GwOoaOOleBcS0UdPnFoXwgrnM/?name=image923295.png",
-                    "content_type": "image/png",
-                    "size": 7631,
-                    "width": null,
-                    "height": null,
-                    "inline": false,
-                    "deleted": false,
-                    "malware_access_override": false,
-                    "malware_scan_result": "malware_not_found",
-                    "thumbnails": [
-                        {
-                            "url": "https://subdomain.zendesk.com/api/v2/attachments/25459067055377.json",
-                            "id": 25459067055377,
-                            "file_name": "image923295_thumb.png",
-                            "content_url": "https://subdomain.zendesk.com/attachments/token/f1rBPprz4lXwf7jX1YiXkzeYv/?name=image923295_thumb.png",
-                            "mapped_content_url": "https://helpdesk.subdomain.com/attachments/token/f1rBPprz4lXwf7jX1YiXkzeYv/?name=image923295_thumb.png",
-                            "content_type": "image/png",
-                            "size": 4004,
-                            "width": 80,
-                            "height": 70,
-                            "inline": false,
-                            "deleted": false,
-                            "malware_access_override": false,
-                            "malware_scan_result": "not_scanned"
-                        }
-                    ]
-                }
-            ],
-            "recipient": "example@subdomain.zendesk.com",
-            "brand_id": 3173256
-        }
-    ],
-    "meta": {
-        "has_more": true,
-        "after_cursor": "aCursor",
-        "before_cursor": "bCursor"
-    },
-    "links": {
-        "prev": "https://subdomain.zendesk.com/api/v2/suspended_tickets.json?page%5Bbefore%5D=bCursor&page%5Bsize%5D=1",
-        "next": "https://subdomain.zendesk.com/api/v2/suspended_tickets.json?page%5Bafter%5D=aCursor&page%5Bsize%5D=1"
-    }
+	"suspended_tickets": [
+		{
+			"url": "https://subdomain.zendesk.com/api/v2/suspended_tickets/12345.json",
+			"id": 12345,
+			"author": {
+				"id": null,
+				"name": "Kylo Ren",
+				"email": "KyloRen@stars.com"
+			},
+			"subject": "RE: Support #67894 - product running out of space",
+			"content": "some sort of content",
+			"cause": "User must sign up to submit email; user notified",
+			"cause_id": 12,
+			"error_messages": null,
+			"message_id": "<124ASDJHASF1283AH@TADBA.SOMETHING.prod.outlook.com>",
+			"ticket_id": 67894,
+			"created_at": "2024-05-29T01:09:12Z",
+			"updated_at": "2024-05-29T01:09:12Z",
+			"via": {
+				"channel": "email",
+				"source": {
+					"from": {
+						"address": "KyloRen@stars.com",
+						"name": "Kylo Ren"
+					},
+					"to": {
+						"name": "Subdomain Support",
+						"address": "support@subdomain.zendesk.com"
+					},
+					"rel": null
+				}
+			},
+			"attachments": [
+				{
+					"url": "https://subdomain.zendesk.com/api/v2/attachments/12345.json",
+					"id": 12345,
+					"file_name": "12345.png",
+					"content_url": "https://subdomain.zendesk.com/attachments/token/GwOoaOOleBcS0UdPnFoXwgrnM/?name=image923295.png",
+					"mapped_content_url": "https://helpdesk.subdomain.com/attachments/token/GwOoaOOleBcS0UdPnFoXwgrnM/?name=image923295.png",
+					"content_type": "image/png",
+					"size": 7631,
+					"width": null,
+					"height": null,
+					"inline": false,
+					"deleted": false,
+					"malware_access_override": false,
+					"malware_scan_result": "malware_not_found",
+					"thumbnails": [
+						{
+							"url": "https://subdomain.zendesk.com/api/v2/attachments/25459067055377.json",
+							"id": 25459067055377,
+							"file_name": "image923295_thumb.png",
+							"content_url": "https://subdomain.zendesk.com/attachments/token/f1rBPprz4lXwf7jX1YiXkzeYv/?name=image923295_thumb.png",
+							"mapped_content_url": "https://helpdesk.subdomain.com/attachments/token/f1rBPprz4lXwf7jX1YiXkzeYv/?name=image923295_thumb.png",
+							"content_type": "image/png",
+							"size": 4004,
+							"width": 80,
+							"height": 70,
+							"inline": false,
+							"deleted": false,
+							"malware_access_override": false,
+							"malware_scan_result": "not_scanned"
+						}
+					]
+				}
+			],
+			"recipient": "example@subdomain.zendesk.com",
+			"brand_id": 3173256
+		}
+	],
+	"meta": {
+		"has_more": true,
+		"after_cursor": "aCursor",
+		"before_cursor": "bCursor"
+	},
+	"links": {
+		"prev": "https://subdomain.zendesk.com/api/v2/suspended_tickets.json?page%5Bbefore%5D=bCursor&page%5Bsize%5D=1",
+		"next": "https://subdomain.zendesk.com/api/v2/suspended_tickets.json?page%5Bafter%5D=aCursor&page%5Bsize%5D=1"
+	}
 }

--- a/zendesk/test_files/responses/support/suspended_ticket/list_page1_200.json
+++ b/zendesk/test_files/responses/support/suspended_ticket/list_page1_200.json
@@ -1,0 +1,81 @@
+{
+    "suspended_tickets": [
+        {
+            "url": "https://kaseya.zendesk.com/api/v2/suspended_tickets/12345.json",
+            "id": 12345,
+            "author": {
+                "id": null,
+                "name": "Kylo Ren",
+                "email": "KyloRen@stars.com"
+            },
+            "subject": "RE: Support #67894 - product running out of space",
+            "content": "some sort of content",
+            "cause": "User must sign up to submit email; user notified",
+            "cause_id": 12,
+            "error_messages": null,
+            "message_id": "<124ASDJHASF1283AH@TADBA.SOMETHING.prod.outlook.com>",
+            "ticket_id": 67894,
+            "created_at": "2024-05-29T01:09:12Z",
+            "updated_at": "2024-05-29T01:09:12Z",
+            "via": {
+                "channel": "email",
+                "source": {
+                    "from": {
+                        "address": "KyloRen@stars.com",
+                        "name": "Kylo Ren"
+                    },
+                    "to": {
+                        "name": "Subdomain Support",
+                        "address": "support@subdomain.zendesk.com"
+                    },
+                    "rel": null
+                }
+            },
+            "attachments": [
+                {
+                    "url": "https://subdomain.zendesk.com/api/v2/attachments/12345.json",
+                    "id": 12345,
+                    "file_name": "12345.png",
+                    "content_url": "https://subdomain.zendesk.com/attachments/token/GwOoaOOleBcS0UdPnFoXwgrnM/?name=image923295.png",
+                    "mapped_content_url": "https://helpdesk.subdomain.com/attachments/token/GwOoaOOleBcS0UdPnFoXwgrnM/?name=image923295.png",
+                    "content_type": "image/png",
+                    "size": 7631,
+                    "width": null,
+                    "height": null,
+                    "inline": false,
+                    "deleted": false,
+                    "malware_access_override": false,
+                    "malware_scan_result": "malware_not_found",
+                    "thumbnails": [
+                        {
+                            "url": "https://subdomain.zendesk.com/api/v2/attachments/25459067055377.json",
+                            "id": 25459067055377,
+                            "file_name": "image923295_thumb.png",
+                            "content_url": "https://subdomain.zendesk.com/attachments/token/f1rBPprz4lXwf7jX1YiXkzeYv/?name=image923295_thumb.png",
+                            "mapped_content_url": "https://helpdesk.subdomain.com/attachments/token/f1rBPprz4lXwf7jX1YiXkzeYv/?name=image923295_thumb.png",
+                            "content_type": "image/png",
+                            "size": 4004,
+                            "width": 80,
+                            "height": 70,
+                            "inline": false,
+                            "deleted": false,
+                            "malware_access_override": false,
+                            "malware_scan_result": "not_scanned"
+                        }
+                    ]
+                }
+            ],
+            "recipient": "example@subdomain.zendesk.com",
+            "brand_id": 3173256
+        }
+    ],
+    "meta": {
+        "has_more": true,
+        "after_cursor": "aCursor",
+        "before_cursor": "bCursor"
+    },
+    "links": {
+        "prev": "https://subdomain.zendesk.com/api/v2/suspended_tickets.json?page%5Bbefore%5D=bCursor&page%5Bsize%5D=1",
+        "next": "https://subdomain.zendesk.com/api/v2/suspended_tickets.json?page%5Bafter%5D=aCursor&page%5Bsize%5D=1"
+    }
+}

--- a/zendesk/test_files/responses/support/suspended_ticket/list_page2_200.json
+++ b/zendesk/test_files/responses/support/suspended_ticket/list_page2_200.json
@@ -1,7 +1,7 @@
 {
 	"suspended_tickets": [
 		{
-			"url": "https://kaseya.zendesk.com/api/v2/suspended_tickets/12346.json",
+			"url": "https://subdomain.zendesk.com/api/v2/suspended_tickets/12346.json",
 			"id": 12346,
 			"author": {
 				"id": null,

--- a/zendesk/test_files/responses/support/suspended_ticket/list_page2_200.json
+++ b/zendesk/test_files/responses/support/suspended_ticket/list_page2_200.json
@@ -1,0 +1,48 @@
+{
+	"suspended_tickets": [
+		{
+			"url": "https://kaseya.zendesk.com/api/v2/suspended_tickets/12346.json",
+			"id": 12346,
+			"author": {
+				"id": null,
+				"name": "Kylo Ren",
+				"email": "KyloRen@stars.com"
+			},
+			"subject": "RE: Support #67895 - Another product running out of space",
+			"content": "some sort of content",
+			"cause": "User must sign up to submit email; user notified",
+			"cause_id": 12,
+			"error_messages": null,
+			"message_id": "<124ASDJHASF1283AH@TADBA.SOMETHING.prod.outlook.com>",
+			"ticket_id": 67895,
+			"created_at": "2024-05-29T01:09:12Z",
+			"updated_at": "2024-05-29T01:09:12Z",
+			"via": {
+				"channel": "email",
+				"source": {
+					"from": {
+						"address": "KyloRen@stars.com",
+						"name": "Kylo Ren"
+					},
+					"to": {
+						"name": "Subdomain Support",
+						"address": "support@subdomain.zendesk.com"
+					},
+					"rel": null
+				}
+			},
+			"attachments": null,
+			"recipient": "example@subdomain.zendesk.com",
+			"brand_id": 3173256
+		}
+	],
+	"meta": {
+		"has_more": false,
+		"after_cursor": "cCursor",
+		"before_cursor": "dCursor"
+	},
+	"links": {
+		"prev": "https://subdomain.zendesk.com/api/v2/suspended_tickets.json?page%5Bbefore%5D=dCursor&page%5Bsize%5D=1",
+		"next": "https://subdomain.zendesk.com/api/v2/suspended_tickets.json?page%5Bafter%5D=cCursor&page%5Bsize%5D=1"
+	}
+}

--- a/zendesk/test_files/responses/support/suspended_ticket/show_200.json
+++ b/zendesk/test_files/responses/support/suspended_ticket/show_200.json
@@ -1,0 +1,31 @@
+{
+    "suspended_ticket": {
+        "url": "https://subdomain.zendesk.com/api/v2/suspended_tickets/12345.json",
+        "id": 12345,
+        "author": {
+            "id": 45678,
+            "name": "A Support Company",
+            "email": "support@supportcomapny.au"
+        },
+        "subject": "Faulty Product",
+        "content": "The product does not power on, it was setup with another product and this one died unexpectedly. ",
+        "cause": "Detected as spam",
+        "cause_id": 0,
+        "error_messages": null,
+        "message_id": null,
+        "ticket_id": null,
+        "created_at": "2024-05-29T07:07:11Z",
+        "updated_at": "2024-05-29T07:07:11Z",
+        "via": {
+            "channel": "web",
+            "source": {
+                "from": {},
+                "to": {},
+                "rel": null
+            }
+        },
+        "attachments": [],
+        "recipient": null,
+        "brand_id": 1234
+    }
+}


### PR DESCRIPTION
### Enhancement: Add another field to the Suspended Ticket endpoint and include tests  
Adds the "content" field to the Suspended Ticket object, which contains details about the suspended ticket body.  

While adding this field, I also added the Show endpoint (as I used this to verify the payload details) and added tests for most existing endpoints.  

